### PR TITLE
Fix "Add/Switch to Arbitrum Network" button

### DIFF
--- a/src/util/web3.ts
+++ b/src/util/web3.ts
@@ -20,7 +20,7 @@ export function web3Injected(
 }
 
 export async function requestNetworkSwitch(network: Network) {
-  const chainId = ethers.BigNumber.from(network.chainID).toHexString()
+  const chainId = ethers.utils.hexValue(ethers.BigNumber.from(network.chainID))
   if (web3Injected(window.ethereum)) {
     try {
       await window.ethereum.request?.({


### PR DESCRIPTION
Currently clicking "Add/Switch to Arbitrum Network" causes the following error to be printed to the console and prevents MetaMask from popping up:

`"Expected 0x-prefixed, unpadded, non-zero hexadecimal string 'chainId'. Received: 0x066eeb"`

`ethers.utils.hexValue` strips leading zeros from the chainId string which fixes the bug.