### PR TITLE
fix pending withdrawal decimals

### DIFF
--- a/src/state/app/state.ts
+++ b/src/state/app/state.ts
@@ -134,13 +134,7 @@ export const defaultState: AppState = {
         asset: tx.symbol?.toLocaleLowerCase(),
         value: ethers.utils.formatUnits(
           tx.value?.toString(),
-          tx.tokenAddress
-            ? (
-                s.arbTokenBridge?.bridgeTokens[
-                  tx.tokenAddress
-                ] as ERC20BridgeToken
-              )?.decimals || 18
-            : 18
+          tx.decimals
         ),
         uniqueId: tx.uniqueId,
         isWithdrawal: true,


### PR DESCRIPTION
fixes https://github.com/OffchainLabs/arb-token-bridge/issues/71

this was a bug inherited from the old UI; with https://github.com/OffchainLabs/token-bridge-sdk/commit/27ca37b37a19be38bc8905f1e2e1574012381c20, we ensure we have access to the current token's decimals (otherwise it may not currently be included in BridgeTokens)