### PR TITLE
display OutgoingMessageState "NOT_FOUND" as "unconfirmed"

### DIFF
--- a/src/state/app/state.ts
+++ b/src/state/app/state.ts
@@ -41,7 +41,7 @@ export interface MergedTransaction {
 }
 
 const outgoungStateToString = {
-  [OutgoingMessageState.NOT_FOUND]: 'Not Found',
+  [OutgoingMessageState.NOT_FOUND]: 'Unconfirmed',
   [OutgoingMessageState.UNCONFIRMED]: 'Unconfirmed',
   [OutgoingMessageState.CONFIRMED]: 'Confirmed',
   [OutgoingMessageState.EXECUTED]: 'Executed'


### PR DESCRIPTION
fixes https://github.com/OffchainLabs/arb-token-bridge/issues/136