### PR TITLE
Fix adding token by l2 address

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -196,11 +196,7 @@ export const TokenModalBody = ({
   }, [bridgeTokens, isDepositMode, newToken, balances])
 
   const storeNewToken = async () => {
-    return bridge?.l1Bridge
-      .getL1TokenData(newToken) // check if exitss first before adding, because sdk will add to the cache even if it does not exist
-      .then(async () => {
-        await token.add(newToken)
-      })
+    return token.add(newToken)
       .catch(ex => {
         console.log('Token not found on this network', ex)
       })

--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -196,10 +196,9 @@ export const TokenModalBody = ({
   }, [bridgeTokens, isDepositMode, newToken, balances])
 
   const storeNewToken = async () => {
-    return token.add(newToken)
-      .catch(ex => {
-        console.log('Token not found on this network', ex)
-      })
+    return token.add(newToken).catch(ex => {
+      console.log('Token not found on this network', ex)
+    })
   }
 
   const addNewToken: FormEventHandler = async e => {

--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -200,9 +200,6 @@ export const TokenModalBody = ({
       .catch(ex => {
         console.log('Token not found on this network', ex)
       })
-      .finally(() => {
-        setNewToken('')
-      })
   }
 
   const addNewToken: FormEventHandler = async e => {


### PR DESCRIPTION
Codepath wasn't using the sdk method, which handles L1 and L2 addresses

Can try it out w/ 0xfeA31d704DEb0975dA8e77Bf13E04239e70d7c28 (mainnet)