### PR TITLE
fix network switch bug: check  arbTokenBridgeLoaded in TokenButton

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -9,7 +9,8 @@ const TokenButton = (): JSX.Element => {
     app: {
       selectedToken,
       networkID,
-      arbTokenBridge: { bridgeTokens }
+      arbTokenBridge: { bridgeTokens },
+      arbTokenBridgeLoaded
     }
   } = useAppState()
   const [tokeModalOpen, setTokenModalOpen] = useState(false)
@@ -19,7 +20,7 @@ const TokenButton = (): JSX.Element => {
     if (!selectedAddress) {
       return 'https://ethereum.org/static/4b5288012dc4b32ae7ff21fccac98de1/31987/eth-diamond-black-gray.png'
     }
-    if (networkID === null) {
+    if (networkID === null || !arbTokenBridgeLoaded) {
       return undefined
     }
     const logo = bridgeTokens[selectedAddress]?.logoURI


### PR DESCRIPTION
To repro: trigger a token withdraw while connected  to the L1 side, and after the network switch, w/ a bit of luck, the page will error. 

I'd rather change the default arbTokenBridge state to null for initial load (here https://github.com/OffchainLabs/arb-token-bridge/blob/ecc62b372203322454da95b2b49c64c2489be835/packages/arb-token-bridge-ui/src/state/app/state.ts#L86) and do away w/ arbTokenBridgeLoaded altogether, but I'd want to first confirm that that doesn't break other assumptions. 