### PR TITLE
add explicit disabled/paused check

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -196,10 +196,10 @@ export const TokenModalBody = ({
   }, [bridgeTokens, isDepositMode, newToken, balances])
 
   const storeNewToken = async () => {
-    return token.add(newToken).catch((ex:Error) => {
+    return token.add(newToken).catch((ex: Error) => {
       console.log('Token not found on this network')
-      if(ex.name === 'TokenDisabledError'){
-        alert("This token is currently paused in the bridge")
+      if (ex.name === 'TokenDisabledError') {
+        alert('This token is currently paused in the bridge')
       }
     })
   }

--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -196,8 +196,11 @@ export const TokenModalBody = ({
   }, [bridgeTokens, isDepositMode, newToken, balances])
 
   const storeNewToken = async () => {
-    return token.add(newToken).catch(ex => {
-      console.log('Token not found on this network', ex)
+    return token.add(newToken).catch((ex:Error) => {
+      console.log('Token not found on this network')
+      if(ex.name === 'TokenDisabledError'){
+        alert("This token is currently paused in the bridge")
+      }
     })
   }
 


### PR DESCRIPTION
adding via l2 address (for a token that was already registered but then paused) was slipping through the cracks; this is a keep-it-simple-stupid check at the end