### PR TITLE
sanity check current connected wallet before deposit/withdraw action

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useMemo, useCallback } from 'react'
 
+import { useWallet } from '@gimmixorg/use-wallet'
 import { utils, BigNumber } from 'ethers'
 import Loader from 'react-loader-spinner'
 import { useLatest } from 'react-use'
@@ -37,6 +38,7 @@ const TransferPanel = (): JSX.Element => {
       isDepositMode,
       networkDetails,
       l1NetworkDetails,
+      l2NetworkDetails,
       pendingTransactions,
       arbTokenBridgeLoaded,
       arbTokenBridge: { eth, token, bridgeTokens },
@@ -44,6 +46,8 @@ const TransferPanel = (): JSX.Element => {
       warningTokens
     }
   } = useAppState()
+  const { provider } = useWallet()
+  const latestConnectedProvider = useLatest(provider)
 
   const bridge = useContext(BridgeContext)
   // const [tokeModalOpen, setTokenModalOpen] = useState(false)
@@ -167,6 +171,15 @@ const TransferPanel = (): JSX.Element => {
           }
           await new Promise(r => setTimeout(r, 3000))
         }
+
+        const l1ChainID = l1NetworkDetails?.chainID
+        const connectedChainID =
+          latestConnectedProvider.current?.network?.chainId
+        if (
+          !(l1ChainID && connectedChainID && +l1ChainID === connectedChainID)
+        ) {
+          return alert('Network connection issue; contact support')
+        }
         if (selectedToken) {
           const { decimals } = selectedToken
           const amountRaw = utils.parseUnits(amount, decimals)
@@ -199,6 +212,15 @@ const TransferPanel = (): JSX.Element => {
             await new Promise(r => setTimeout(r, 100))
           }
           await new Promise(r => setTimeout(r, 3000))
+        }
+
+        const l2ChainID = l2NetworkDetails?.chainID
+        const connectedChainID =
+          latestConnectedProvider.current?.network?.chainId
+        if (
+          !(l2ChainID && connectedChainID && +l2ChainID === connectedChainID)
+        ) {
+          return alert('Network connection issue; contact support')
         }
         if (selectedToken) {
           const { decimals } = selectedToken


### PR DESCRIPTION
There are cases in which a action is being taken against the wrong network  (i.e.) https://etherscan.io/tx/0x4c9e6855be18ee310a9e83f4c1b3b81d66782286d1c7f16a578c47cf300df4c1

My best guess (still haven't reproduced) is that that wallet_switchEthereumChain fails silently for some combo of metamask versions and browsers (?), which leads to a signer speaking to a mismatched connected wallet. 

This "can't hurt" check should prevent it while we figure out how to better handle it.