### PR TITLE
handle arb token lists with L1 tokens

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -270,19 +270,19 @@ export const TokenModalBody = ({
           if (!bal2) {
             return -1
           }
-
           return bal1.gt(bal2) ? -1 : 1
         })
         .filter((addr: string) => {
           if (!tokenSearch) {
             const l1Bal = balances.erc20[addr]?.balance
             const l2Bal = balances.erc20[addr]?.arbChainBalance
-
-            return !(
-              l1Bal &&
-              l1Bal.eq(constants.Zero) &&
-              l2Bal &&
-              l2Bal.eq(constants.Zero)
+            if (!l1Bal && !l2Bal) {
+              // show as loading:
+              return true
+            }
+            return (
+              (l1Bal && l1Bal.gt(constants.Zero)) ||
+              (l2Bal && l2Bal.gt(constants.Zero))
             )
           }
           const bridgeToken = bridgeTokens[addr]

--- a/packages/arb-token-bridge-ui/src/tokenLists.tsx
+++ b/packages/arb-token-bridge-ui/src/tokenLists.tsx
@@ -23,7 +23,7 @@ export const BRIDGE_TOKEN_LISTS: BridgeTokenList[] = [
   {
     id: 2,
     originChainID: '42161',
-    url: 'https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_default_list.json',
+    url: 'https://tokenlist.arbitrum.io/ArbTokenLists/arbed_uniswap_labs_list.json',
     name: 'Arbed Uniswap List',
     isDefault: true,
     logoURI:

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -381,6 +381,12 @@ export const useArbTokenBridge = (
   }
   
   const addTokensFromList = async (arbTokenList: TokenList, listID?: number) => {
+    const { l1Bridge: { network: { chainID: l1ChainIStr } }, l2Bridge: { network: { chainID: l2ChainIDStr } }  } = bridge
+
+    const l1ChainID = + l1ChainIStr
+    const l2ChainID = + l2ChainIDStr
+
+
     const bridgeTokensToAdd: ContractStorage<ERC20BridgeToken> = {}
     for (const tokenData of arbTokenList.tokens) {
       const {
@@ -389,8 +395,13 @@ export const useArbTokenBridge = (
         symbol,
         extensions,
         decimals,
-        logoURI
+        logoURI,
+        chainId
       } = tokenData
+
+      if(![l1ChainID, l2ChainID].includes(chainId)){
+        continue
+      }
 
       const bridgeInfo = (() => {
         // TODO: parsing the token list format could be from arbts or the tokenlist package

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -384,7 +384,7 @@ export const useArbTokenBridge = (
     const bridgeTokensToAdd: ContractStorage<ERC20BridgeToken> = {}
     for (const tokenData of arbTokenList.tokens) {
       const {
-        address: l2Address,
+        address,
         name,
         symbol,
         extensions,
@@ -416,23 +416,40 @@ export const useArbTokenBridge = (
                 'destBridgeAddress' in e
             )
         }
-        if (!isExtensions(extensions))
-          throw new Error('Object not of BridgeInfo format')
-        return extensions.bridgeInfo
+        if (!isExtensions(extensions)){
+          return null
+        } else {
+          return extensions.bridgeInfo
+        }
       })()
 
-      const l1Address = bridgeInfo[await l1NetworkIDCached()].tokenAddress
+      if(bridgeInfo){
+        const l1Address = bridgeInfo[await l1NetworkIDCached()].tokenAddress
 
-      bridgeTokensToAdd[l1Address] = {
-        name,
-        type: TokenType.ERC20,
-        symbol,
-        allowed: false,
-        address: l1Address,
-        l2Address,
-        decimals,
-        logoURI,
-        listID
+        bridgeTokensToAdd[l1Address] = {
+          name,
+          type: TokenType.ERC20,
+          symbol,
+          allowed: false,
+          address: l1Address,
+          l2Address: address,
+          decimals,
+          logoURI,
+          listID
+        }
+      } else {
+        // unbridged L1 token:
+        const l1Address = address
+        bridgeTokensToAdd[l1Address] = {
+          name,
+          type: TokenType.ERC20,
+          symbol,
+          allowed: false,
+          address: l1Address,
+          decimals,
+          logoURI,
+          listID
+        }
       }
     }
     setBridgeTokens(oldBridgeTokens => {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -437,8 +437,11 @@ export const useArbTokenBridge = (
           logoURI,
           listID
         }
-      } else {
-        // unbridged L1 token:
+      }
+      // unbridged L1 token:
+      // stopgap: giant lists (i.e., CMC list) currently severaly hurts page performace, so for now we only add the bridged tokens
+      else if (arbTokenList.tokens.length < 1000) {
+      
         const l1Address = address
         bridgeTokensToAdd[l1Address] = {
           name,


### PR DESCRIPTION
the search-unimported-lists features isn't on this branch; this just sets the groundwork and ensures the UI plays nicely with the new list format https://github.com/OffchainLabs/arb-token-lists/pull/9