### PR TITLE
fix: always check for allowance

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenImportModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenImportModal.tsx
@@ -35,7 +35,6 @@ function toERC20BridgeToken(data: L1TokenData): ERC20BridgeToken {
     name: data.name,
     type: TokenType.ERC20,
     symbol: data.symbol,
-    allowed: data.allowed,
     address: data.contract.address,
     decimals: data.decimals
   }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -261,17 +261,17 @@ const TransferPanel = (): JSX.Element => {
             return
           }
 
-          if (!bridgeTokens[selectedToken.address]?.allowed) {
-            // ** Sanity check: ensure not allowed yet  */
-            const allowed = await isAllowed(
-              bridge,
-              selectedToken.address,
-              amountRaw
-            )
-            if (!allowed) {
-              await latestToken.current.approve(selectedToken.address)
-            }
+          // Sanity check: ensure not allowed yet
+          const allowed = await isAllowed(
+            bridge,
+            selectedToken.address,
+            amountRaw
+          )
+
+          if (!allowed) {
+            await latestToken.current.approve(selectedToken.address)
           }
+
           await latestToken.current.deposit(selectedToken.address, amountRaw)
         } else {
           const amountRaw = utils.parseUnits(amount, 18)

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -27,7 +27,6 @@ export interface BridgeToken {
   type: TokenType
   name: string
   symbol: string
-  allowed: boolean
   address: string
   l2Address?: string
   logoURI?: string

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -450,7 +450,6 @@ export const useArbTokenBridge = (
           name,
           type: TokenType.ERC20,
           symbol,
-          allowed: false,
           address: l1Address,
           l2Address: address,
           decimals,
@@ -466,7 +465,6 @@ export const useArbTokenBridge = (
           name,
           type: TokenType.ERC20,
           symbol,
-          allowed: false,
           address: l1Address,
           decimals,
           logoURI,
@@ -518,7 +516,7 @@ export const useArbTokenBridge = (
       const bridgeTokensToAdd: ContractStorage<ERC20BridgeToken> = {}
 
       const l1Data = await bridge.l1Bridge.getL1TokenData(l1Address)
-      const { symbol, allowed, contract, balance } = l1Data
+      const { symbol, contract, balance } = l1Data
       l1TokenBalance = balance
       const name = await contract.name()
       const decimals = await contract.decimals()
@@ -541,7 +539,6 @@ export const useArbTokenBridge = (
         name,
         type: TokenType.ERC20,
         symbol,
-        allowed,
         address: l1Address,
         l2Address,
         decimals
@@ -618,7 +615,6 @@ export const useArbTokenBridge = (
         ...oldErc20Balances,
         [l1Address]: erc20TokenBalance
       }))
-      bridgeToken.allowed = l1Data.allowed
       const newBridgeTokens = { [l1Address]: bridgeToken }
       setBridgeTokens(oldBridgeTokens => {
         return { ...oldBridgeTokens, ...newBridgeTokens }


### PR DESCRIPTION
The issue with the approval not popping up was caused by us relying on the `allowed` property of the token on https://github.com/OffchainLabs/arb-token-bridge/pull/257/files#diff-286a4ee4334ef698f2f4080f95722061ff721facd19401fdd32279bf686c1e91L264. 

The `allowed` property is determined in `arb-ts` at https://github.com/OffchainLabs/arbitrum/blob/master/packages/arb-ts/src/lib/l1Bridge.ts#L219 by checking if the allowance is greater or equal to half of `0xffffffffffffffffffffffff`, meaning if you set the allowance to be `HALF + 1` and then later want to bridge over `HALF + 100`, the info you'd get was that it was allowed, even though you haven't allowed that amount. 

The fix for the bridge UI was to always check for allowance, and not to rely on the `allowed` property. 

Not sure if any changes need to be made on the SDK side, but regardless this should probably be hotfixed like this for the time being.