### PR TITLE
refactor(sdk): update balances, token approvals and addresses

### DIFF
--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -1343,7 +1343,7 @@ export const useArbTokenBridge = (
       withdraw: withdrawToken,
       triggerOutbox: triggerOutboxToken
     },
-    arbSigner: bridge.l2Bridge.l2Signer,
+    arbSigner: l2.signer,
     transactions: {
       transactions,
       clearPendingTransactions,

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -683,9 +683,10 @@ export const useArbTokenBridge = (
     })
   }, [])
 
-  const updateEthBalances = async () => {
-    const l1Balance = await bridge.getL1EthBalance()
-    const l2Balance = await bridge.getL2EthBalance()
+  async function updateEthBalances() {
+    const l1Balance = await l1.signer.getBalance()
+    const l2Balance = await l2.signer.getBalance()
+
     setEthBalances({
       balance: l1Balance,
       arbChainBalance: l2Balance

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -329,8 +329,15 @@ export const useArbTokenBridge = (
   )
 
   const approveToken = async (erc20L1Address: string) => {
-    const tx = await bridge.approveToken(erc20L1Address)
-    const tokenData = await bridge.l1Bridge.getL1TokenData(erc20L1Address)
+    const erc20Bridger = new Erc20Bridger(l2.network)
+
+    const tx = await erc20Bridger.approveToken({
+      l1Signer: l1.signer,
+      erc20L1Address
+    })
+
+    const tokenData = await getL1TokenData(erc20L1Address)
+
     addTransaction({
       type: 'approve',
       status: 'pending',
@@ -339,10 +346,11 @@ export const useArbTokenBridge = (
       assetName: tokenData.symbol,
       assetType: AssetType.ERC20,
       sender: await walletAddressCached(),
-      l1NetworkID: await l1NetworkIDCached()
+      l1NetworkID: String(l1.network.chainID)
     })
 
     const receipt = await tx.wait()
+
     updateTransaction(receipt, tx)
     updateTokenData(erc20L1Address)
   }

--- a/packages/token-bridge-sdk/src/index.ts
+++ b/packages/token-bridge-sdk/src/index.ts
@@ -20,6 +20,7 @@ export type {
 
 export { txnTypeToLayer } from './hooks/useTransactions'
 
-export { OutgoingMessageState, ERC20__factory, Bridge } from 'arb-ts'
+export { OutgoingMessageState, Bridge } from 'arb-ts'
+export { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 
 export { validateTokenList } from './util/index'


### PR DESCRIPTION
In this PR:
* Switched token approvals to use `@arbitrum/sdk`
* Switched ETH balance updates to use `@arbitrum/sdk`
* Got rid of the `l1NetworkIDCached` callback and added a `l1NetworkID` memoized property
* Added `getL1ERC20Address` and `getL2ERC20Address` which were on the `Bridge` object before
  * Kept the same function signatures to minimize changes 