### PR TITLE
use arbitrum/sdk: retryables strategy

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useContext } from 'react'
+import React, { useState, useMemo, useCallback } from 'react'
 
 import dayjs from 'dayjs'
 import Countdown from 'react-countdown'
@@ -13,7 +13,7 @@ import { Button } from '../common/Button'
 import ExplorerLink from '../common/ExplorerLink'
 import { StatusBadge } from '../common/StatusBadge'
 import { Tooltip } from '../common/Tooltip'
-import {  L1ToL2MessageWriter } from '@arbitrum/sdk'
+import { L1ToL2MessageWriter } from '@arbitrum/sdk'
 import { BigNumber } from 'ethers'
 
 interface TransactionsTableProps {
@@ -32,7 +32,7 @@ const depositStatusDisplayText = (depositStatus: DepositStatus) => {
     case DepositStatus.L2_SUCCESS:
       return 'success'
     case DepositStatus.L2_FAILURE:
-      return 'l2 txn failed; try re-executing' 
+      return 'l2 txn failed; try re-executing'
     case DepositStatus.CREATION_FAILED:
       return 'l2 failed; contact support'
     case DepositStatus.EXPIRED:
@@ -107,17 +107,19 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
     async (tx: MergedTransaction) => {
       const l2Signer = arbTokenBridge.arbSigner
       const retryableCreationTxID = tx.l1ToL2MsgData?.retryableCreationTxID
-      if(!retryableCreationTxID) throw new Error("Can't redeem; txid not found")
-      const l1ToL2Msg = L1ToL2MessageWriter.fromRetryableCreationId(l2Signer,retryableCreationTxID, BigNumber.from(0))
+      if (!retryableCreationTxID)
+        throw new Error("Can't redeem; txid not found")
+      const l1ToL2Msg = L1ToL2MessageWriter.fromRetryableCreationId(
+        l2Signer,
+        retryableCreationTxID,
+        BigNumber.from(0)
+      )
       const res = await l1ToL2Msg.redeem()
       const rec = await res.wait()
       // update in store
-      arbTokenBridge.transactions.updateL1ToL2MsgData(
-        tx.txId,
-        l1ToL2Msg
-      )
+      arbTokenBridge.transactions.updateL1ToL2MsgData(tx.txId, l1ToL2Msg)
     },
-    [ arbTokenBridge ]
+    [arbTokenBridge]
   )
 
   const { blockTime = 15 } = l1NetworkDetails as Network

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -13,6 +13,7 @@ import { Button } from '../common/Button'
 import ExplorerLink from '../common/ExplorerLink'
 import { StatusBadge } from '../common/StatusBadge'
 import { Tooltip } from '../common/Tooltip'
+import { L1ToL2MessageStatus } from "@arbitrum/sdk"
 
 interface TransactionsTableProps {
   transactions: MergedTransaction[]
@@ -65,7 +66,6 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
       l2NetworkDetails,
       isDepositMode,
       currentL1BlockNumber,
-      seqNumToAutoRedeems,
       networkDetails
     }
   } = useAppState()
@@ -74,15 +74,13 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
   const [isClaiming, setIsClaiming] = useState(false)
 
   const showRedeemRetryableButton = useMemo(() => {
-    return (
-      tx.direction === 'deposit-l2' &&
-      tx.asset !== 'eth' &&
-      tx.seqNum !== undefined &&
-      tx.status !== 'success' &&
-      seqNumToAutoRedeems[tx.seqNum] &&
-      seqNumToAutoRedeems[tx.seqNum].status === 'failure'
-    )
-  }, [seqNumToAutoRedeems, tx])
+    if(tx.direction === 'deposit-l1' || tx.direction === 'deposit'){
+       if (tx.l1ToL2MsgData && tx.l1ToL2MsgData.status ===  L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2 && tx.asset !== 'eth'){
+         return true
+       }
+    }
+    return false
+  }, [tx])
 
   const redeemRetryable = useCallback(
     (userTxnHash: string) => {

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -113,7 +113,7 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
       const l1ToL2Msg = L1ToL2MessageWriter.fromRetryableCreationId(
         l2Signer,
         retryableCreationTxID,
-        BigNumber.from(0)
+        BigNumber.from(tx.seqNum)
       )
       const res = await l1ToL2Msg.redeem()
       const rec = await res.wait()

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -240,13 +240,16 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
           return 'yellow'
       }
     } else {
-      return tx.status === 'success'
-        ? 'green'
-        : tx.status === 'failure'
-        ? 'red'
-        : tx.status === 'pending'
-        ? 'blue'
-        : 'yellow'
+      switch (tx.status) {
+        case 'success':
+          return 'green'
+        case 'failure':
+          return 'red'
+        case 'pending':
+          return 'blue'
+        default:
+          return 'yellow'
+      }
     }
   }
 

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -33,7 +33,7 @@ const depositStatusDisplayText = (depositStatus: DepositStatus) => {
     case DepositStatus.L2_SUCCESS:
       return 'success'
     case DepositStatus.L2_FAILURE:
-      return 'l2 failed; try redeeeming' // todo: unclear
+      return 'l2 txn failed; try re-executing' 
     case DepositStatus.CREATION_FAILED:
       return 'l2 failed; contact support'
     case DepositStatus.EXPIRED:
@@ -253,7 +253,6 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
   const renderTxIDDisplay = (tx: MergedTransaction) => {
     if (tx.uniqueId) return tx.uniqueId.toString()
     if (isDeposit(tx)) {
-      // TODO: eth stuff
       const targetL2Tx = (tx => {
         if (!tx.l1ToL2MsgData) return ''
         if (tx.asset === 'eth') {

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -3,6 +3,7 @@ import React, { useState, useMemo, useCallback, useContext } from 'react'
 import dayjs from 'dayjs'
 import Countdown from 'react-countdown'
 import { useAppState } from 'src/state'
+import { DepositStatus } from '../../state/app/state'
 import { Network } from 'src/util/networks'
 import { TxnType } from 'token-bridge-sdk'
 import Loader from 'react-loader-spinner'
@@ -13,11 +14,34 @@ import { Button } from '../common/Button'
 import ExplorerLink from '../common/ExplorerLink'
 import { StatusBadge } from '../common/StatusBadge'
 import { Tooltip } from '../common/Tooltip'
-import { L1ToL2MessageStatus } from "@arbitrum/sdk"
+import { L1ToL2MessageStatus } from '@arbitrum/sdk'
 
 interface TransactionsTableProps {
   transactions: MergedTransaction[]
   overflowX?: boolean
+}
+
+const depositStatusDisplayText = (depositStatus: DepositStatus) => {
+  switch (depositStatus) {
+    case DepositStatus.L1_PENDING:
+      return 'waiting on l1...'
+    case DepositStatus.L1_FAILURE:
+      return 'l1 tx failed'
+    case DepositStatus.L2_PENDING:
+      return 'l1 confirmed, waiting on l2...'
+    case DepositStatus.L2_SUCCESS:
+      return 'success'
+    case DepositStatus.L2_FAILURE:
+      return 'l2 failed; try redeeeming' // todo: unclear
+    case DepositStatus.CREATION_FAILED:
+      return 'l2 failed; contact support'
+    case DepositStatus.EXPIRED:
+      return 'l2 tx expired'
+  }
+}
+
+const isDeposit = (tx: MergedTransaction) => {
+  return tx.direction === 'deposit' || tx.direction === 'deposit-l1'
 }
 
 const PendingCountdown = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
@@ -74,10 +98,8 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
   const [isClaiming, setIsClaiming] = useState(false)
 
   const showRedeemRetryableButton = useMemo(() => {
-    if(tx.direction === 'deposit-l1' || tx.direction === 'deposit'){
-       if (tx.l1ToL2MsgData && tx.l1ToL2MsgData.status ===  L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2 && tx.asset !== 'eth'){
-         return true
-       }
+    if (tx.depositStatus === DepositStatus.L2_FAILURE) {
+      return true
     }
     return false
   }, [tx])
@@ -166,28 +188,93 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
     })`
   }
 
+  const actionDisplayText = (txnType: TxnType) => {
+    switch (tx.direction) {
+      case 'outbox':
+        return 'withdrawal-redeem-on-l1'
+      case 'withdraw':
+        return 'withdrawal-initiated'
+      case 'deposit':
+      case 'deposit-l1':
+        return 'deposit'
+
+      default:
+        return txnType
+    }
+  }
+
+  const statusDisplayText = (tx: MergedTransaction) => {
+    if (tx.depositStatus) {
+      return depositStatusDisplayText(tx.depositStatus)
+    } else {
+      return tx.status
+    }
+  }
+
+  const getStatusVariantColor = (tx: MergedTransaction) => {
+    if (tx.depositStatus) {
+      const { depositStatus } = tx
+
+      switch (depositStatus) {
+        case DepositStatus.L1_PENDING:
+        case DepositStatus.L2_PENDING:
+          return 'blue'
+        case DepositStatus.L1_FAILURE:
+        case DepositStatus.CREATION_FAILED:
+        case DepositStatus.EXPIRED:
+          return 'red'
+        case DepositStatus.L2_SUCCESS:
+          return 'green'
+        case DepositStatus.L2_FAILURE:
+          return 'yellow'
+      }
+    } else {
+      return tx.status === 'success'
+        ? 'green'
+        : tx.status === 'failure'
+        ? 'red'
+        : tx.status === 'pending'
+        ? 'blue'
+        : 'yellow'
+    }
+  }
+
+  const renderTxIDDisplay = (tx: MergedTransaction) => {
+    if (tx.uniqueId) return tx.uniqueId.toString()
+    if (isDeposit(tx)) {
+      // TODO: eth stuff
+      const targetL2Tx = (tx => {
+        if (!tx.l1ToL2MsgData) return ''
+        if (tx.asset === 'eth') {
+          return tx.l1ToL2MsgData.retryableCreationTxID
+        } else {
+          return tx.l1ToL2MsgData.l2TxID
+        }
+      })(tx)
+      return (
+        <>
+          L1: <ExplorerLink hash={tx.txId} type={tx.direction as TxnType} />{' '}
+          <br />
+          {targetL2Tx ? (
+            <>
+              L2: <ExplorerLink hash={targetL2Tx} type={'deposit-l2'} />{' '}
+            </>
+          ) : null}
+        </>
+      )
+    } else {
+      return <ExplorerLink hash={tx.txId} type={tx.direction as TxnType} />
+    }
+  }
+
   return (
     <tr>
       <td className="px-6 py-6 whitespace-nowrap text-sm leading-5 font-normal text-dark-blue">
-        {tx.direction === 'outbox'
-          ? 'withdrawal-redeem-on-l1'
-          : tx.direction === 'withdraw'
-          ? 'withdrawal-initiated'
-          : tx.direction}
+        {actionDisplayText(tx.direction)}
       </td>
       <td className="px-4 py-6  whitespace-nowrap text-sm ">
-        <StatusBadge
-          variant={
-            tx.status === 'success'
-              ? 'green'
-              : tx.status === 'failure'
-              ? 'red'
-              : tx.status === 'pending'
-              ? 'blue'
-              : 'yellow'
-          }
-        >
-          {tx.status}
+        <StatusBadge variant={getStatusVariantColor(tx)}>
+          {statusDisplayText(tx)}
         </StatusBadge>
       </td>
       <td className="px-2 py-6 whitespace-nowrap leading-5 font-normal text-gray-500">
@@ -262,11 +349,7 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
         )}
       </td>
       <td className="px-6 py-6 whitespace-nowrap text-sm leading-5 font-normal text-dark-blue">
-        {tx.uniqueId ? (
-          tx.uniqueId.toString()
-        ) : (
-          <ExplorerLink hash={tx.txId} type={tx.direction as TxnType} />
-        )}
+        {renderTxIDDisplay(tx)}
       </td>
       <td className="px-4 py-6 whitespace-nowrap text-xs leading-4 font-medium text-navy">
         <span className="bg-tokenPill rounded-lg py-1 px-3">{tx.asset}</span>

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -49,7 +49,7 @@ const PendingCountdown = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
   const now = dayjs()
   const whenCreated = dayjs(tx?.createdAt)
   const diffInSeconds = now.diff(whenCreated, 'seconds')
-
+  // TODO update:
   return (
     <Countdown
       date={now

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -9,7 +9,6 @@ import { TxnType } from 'token-bridge-sdk'
 import Loader from 'react-loader-spinner'
 
 import { MergedTransaction } from '../../state/app/state'
-import { BridgeContext } from '../App/App'
 import { Button } from '../common/Button'
 import ExplorerLink from '../common/ExplorerLink'
 import { StatusBadge } from '../common/StatusBadge'
@@ -94,7 +93,6 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
       networkDetails
     }
   } = useAppState()
-  const bridge = useContext(BridgeContext)
 
   const [isClaiming, setIsClaiming] = useState(false)
 
@@ -107,20 +105,19 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
 
   const redeemRetryable = useCallback(
     async (tx: MergedTransaction) => {
-      if (!bridge) return
-      const l2Signer = bridge.l2Bridge.l2Signer
+      const l2Signer = arbTokenBridge.arbSigner
       const retryableCreationTxID = tx.l1ToL2MsgData?.retryableCreationTxID
       if(!retryableCreationTxID) throw new Error("Can't redeem; txid not found")
       const l1ToL2Msg = L1ToL2MessageWriter.fromRetryableCreationId(l2Signer,retryableCreationTxID, BigNumber.from(0))
       const res = await l1ToL2Msg.redeem()
       const rec = await res.wait()
       // update in store
-      arbTokenBridge?.transactions?.updateL1ToL2MsgData(
+      arbTokenBridge.transactions.updateL1ToL2MsgData(
         tx.txId,
         l1ToL2Msg
       )
     },
-    [bridge, arbTokenBridge]
+    [ arbTokenBridge ]
   )
 
   const { blockTime = 15 } = l1NetworkDetails as Network

--- a/packages/arb-token-bridge-ui/src/components/common/ExplorerLink.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/ExplorerLink.tsx
@@ -23,12 +23,10 @@ const ExplorerLink = ({ hash, type, layer }: ExplorerLinkProps) => {
       case 'deposit':
       case 'deposit-l1':
       case 'approve':
-      case 'connext-deposit':
       case 'outbox':
         return `${l1Prefix}/tx/${hash}`
       case 'deposit-l2':
       case 'withdraw':
-      case 'connext-withdraw':
       case 'deposit-l2-auto-redeem':
       case 'deposit-l2-ticket-created':
         return `${l2Prefix}/tx/${hash}`
@@ -57,7 +55,7 @@ const ExplorerLink = ({ hash, type, layer }: ExplorerLinkProps) => {
       className="w-24 relative group"
     >
       <span className="truncate">
-        {hash.substr(0, 15)}...{hash.substr(hash.length - 4)}
+        {hash.substr(0, 10)}...{hash.substr(hash.length - 4)}
         <Tooltip>{hash}</Tooltip>
       </span>
     </a>

--- a/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
@@ -3,7 +3,7 @@ import { useActions, useAppState } from '../../state'
 import { BridgeContext } from '../App/App'
 
 import { useInterval } from '../common/Hooks'
-import { L1TransactionReceipt } from '@arbitrum/sdk'
+import { L1TransactionReceipt, L1ToL2MessageStatus } from '@arbitrum/sdk'
 
 const RetryableTxnsIncluder = (): JSX.Element => {
   const actions = useActions()
@@ -11,6 +11,30 @@ const RetryableTxnsIncluder = (): JSX.Element => {
     app: { arbTokenBridge, arbTokenBridgeLoaded }
   } = useAppState()
   const bridge = useContext(BridgeContext)
+
+  const checkAndUpdateFailedRetryables = useCallback(async () => {
+    if (!bridge) {
+      return
+    }
+    const failedRetryablesToRedeem = actions.app.getFailedRetryablesToRedeem()
+
+    for (let depositTx of failedRetryablesToRedeem) {
+      const depositTxRec = new L1TransactionReceipt(
+        await bridge.l1Provider.getTransactionReceipt(depositTx.txId)
+      ) //**TODO: not found, i.e., reorg */
+      const l1ToL2Msg = await depositTxRec.getL1ToL2Message(
+        bridge.l2Bridge.l2Signer
+      )
+      const status = await l1ToL2Msg.status()
+      if (status !== L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2) {
+        arbTokenBridge?.transactions?.updateL1ToL2MsgData(
+          depositTx.txId,
+          l1ToL2Msg,
+          status
+        )
+      }
+    }
+  }, [arbTokenBridge?.transactions?.addTransactions, bridge])
 
   /**
    * For every L1 deposit, we ensure the relevant L1ToL2MessageIsIncluded
@@ -42,9 +66,16 @@ const RetryableTxnsIncluder = (): JSX.Element => {
     checkAndAddMissingL1ToL2Messagges,
     5000
   )
+
+  const { forceTrigger: forceTriggerUpdateFailedRetryables } = useInterval(
+    checkAndUpdateFailedRetryables,
+    10000
+  )
+
   useEffect(() => {
     // force trigger update each time loaded change happens
     forceTriggerUpdate()
+    forceTriggerUpdateFailedRetryables()
   }, [arbTokenBridgeLoaded])
 
   return <></>

--- a/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
@@ -18,7 +18,7 @@ const RetryableTxnsIncluder = (): JSX.Element => {
     if (!bridge) {
       return
     }
-
+    // TODO check for failures
     const successfulL1Deposits = actions.app.getSuccessfulL1Deposits()
 
     for (let depositTx of successfulL1Deposits.filter(
@@ -27,13 +27,9 @@ const RetryableTxnsIncluder = (): JSX.Element => {
       const depositTxRec = new L1TransactionReceipt(
         await bridge.l1Provider.getTransactionReceipt(depositTx.txID)
       ) //**todo: not found, i.e., reorg */
-      const l1ToL2Msgs = await depositTxRec.getL1ToL2Messages(bridge.l1Provider)
-      if (l1ToL2Msgs.length !== 1) {
-        // TODO: error handle
-      }
+      const l1ToL2Msg = await depositTxRec.getL1ToL2Message(bridge.l2Provider)
 
-      const l1ToL2Msg = l1ToL2Msgs[0]
-      arbTokenBridge?.transactions?.addL1ToL2MsgToDepositTxn(
+      arbTokenBridge?.transactions?.updateL1ToL2MsgData(
         depositTx.txID,
         l1ToL2Msg
       )
@@ -42,7 +38,7 @@ const RetryableTxnsIncluder = (): JSX.Element => {
 
   const { forceTrigger: forceTriggerUpdate } = useInterval(
     checkAndAddMissingL1ToL2Messagges,
-    4000
+    5000
   )
   useEffect(() => {
     // force trigger update each time loaded change happens

--- a/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
@@ -21,9 +21,7 @@ const RetryableTxnsIncluder = (): JSX.Element => {
     // TODO check for failures
     const successfulL1Deposits = actions.app.getSuccessfulL1Deposits()
 
-    for (let depositTx of successfulL1Deposits.filter(
-      depositTx => !depositTx.l1ToL2MsgData
-    )) {
+    for (let depositTx of successfulL1Deposits) {
       const depositTxRec = new L1TransactionReceipt(
         await bridge.l1Provider.getTransactionReceipt(depositTx.txID)
       ) //**todo: not found, i.e., reorg */

--- a/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useActions, useAppState } from '../../state'
 import { useInterval } from '../common/Hooks'
 import { L1TransactionReceipt } from '@arbitrum/sdk'
@@ -17,23 +17,26 @@ const RetryableTxnsIncluder = (): JSX.Element => {
       return
     }
     const { provider: l1Provider } = arbTokenBridge.l1Signer
-    if(!l1Provider){
+    if (!l1Provider) {
       return
     }
-    const l1DepositsWithUntrackedL2Messages = actions.app.l1DepositsWithUntrackedL2Messages()
+    const l1DepositsWithUntrackedL2Messages =
+      actions.app.l1DepositsWithUntrackedL2Messages()
 
     for (let depositTx of l1DepositsWithUntrackedL2Messages) {
       const depositTxRec = new L1TransactionReceipt(
         await l1Provider.getTransactionReceipt(depositTx.txID)
       ) //**TODO: not found, i.e., reorg */
-      const l1ToL2Msg = await depositTxRec.getL1ToL2Message(arbTokenBridge.arbSigner)
+      const l1ToL2Msg = await depositTxRec.getL1ToL2Message(
+        arbTokenBridge.arbSigner
+      )
 
       arbTokenBridge?.transactions?.updateL1ToL2MsgData(
         depositTx.txID,
         l1ToL2Msg
       )
     }
-  }, [ arbTokenBridge?.transactions?.addTransactions])
+  }, [arbTokenBridge?.transactions?.addTransactions])
 
   const { forceTrigger: forceTriggerUpdate } = useInterval(
     checkAndAddMissingL1ToL2Messagges,

--- a/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
@@ -18,13 +18,12 @@ const RetryableTxnsIncluder = (): JSX.Element => {
     if (!bridge) {
       return
     }
-    // TODO check for failures
-    const successfulL1Deposits = actions.app.getSuccessfulL1Deposits()
+    const l1DepositsWithUntrackedL2Messages = actions.app.l1DepositsWithUntrackedL2Messages()
 
-    for (let depositTx of successfulL1Deposits) {
+    for (let depositTx of l1DepositsWithUntrackedL2Messages) {
       const depositTxRec = new L1TransactionReceipt(
         await bridge.l1Provider.getTransactionReceipt(depositTx.txID)
-      ) //**todo: not found, i.e., reorg */
+      ) //**TODO: not found, i.e., reorg */
       const l1ToL2Msg = await depositTxRec.getL1ToL2Message(bridge.l2Provider)
 
       arbTokenBridge?.transactions?.updateL1ToL2MsgData(

--- a/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/RetryableTxnsIncluder.tsx
@@ -1,8 +1,4 @@
 import { useCallback, useContext, useEffect } from 'react'
-
-import { BigNumber } from 'ethers'
-import { AssetType, Transaction, useArbTokenBridge } from 'token-bridge-sdk'
-
 import { useActions, useAppState } from '../../state'
 import { BridgeContext } from '../App/App'
 import { useInterval } from '../common/Hooks'
@@ -12,53 +8,9 @@ const RetryableTxnsIncluder = (): JSX.Element => {
   const bridge = useContext(BridgeContext)
   const actions = useActions()
   const {
-    app: { arbTokenBridge, l2NetworkDetails, arbTokenBridgeLoaded }
+    app: { arbTokenBridge, arbTokenBridgeLoaded }
   } = useAppState()
 
-  const getL2TxnHashes = useCallback(
-    async (depositTxn: Transaction) => {
-      if (!bridge || !l2NetworkDetails) {
-        return null
-      }
-      let seqNum: BigNumber
-      if (depositTxn.seqNum) {
-        seqNum = BigNumber.from(depositTxn.seqNum)
-      } else {
-        // for backwards compatibility, add seqNum to cached old deposits
-        const rec = await bridge.l1Provider.getTransactionReceipt(
-          depositTxn.txID
-        )
-        const seqNumArray = await bridge.getInboxSeqNumFromContractTransaction(
-          rec
-        )
-        if (!seqNumArray || seqNumArray.length === 0) {
-          return null
-        }
-        ;[seqNum] = seqNumArray
-      }
-
-      const l2ChainID = BigNumber.from(l2NetworkDetails.chainID)
-      const retryableTicketHash = await bridge.calculateL2TransactionHash(
-        seqNum,
-        l2ChainID
-      )
-      const autoRedeemHash = await bridge.calculateRetryableAutoRedeemTxnHash(
-        seqNum,
-        l2ChainID
-      )
-      const userTxnHash = await bridge.calculateL2RetryableTransactionHash(
-        seqNum,
-        l2ChainID
-      )
-      return {
-        retryableTicketHash,
-        autoRedeemHash,
-        userTxnHash,
-        seqNum
-      }
-    },
-    [useArbTokenBridge, l2NetworkDetails]
-  )
   /**
    * For every L1 deposit, we ensure the relevant L1ToL2MessageIsIncluded
    */
@@ -86,73 +38,6 @@ const RetryableTxnsIncluder = (): JSX.Element => {
         l1ToL2Msg
       )
     }
-    // const sortedTransactions = actions.app.getSortedTransactions()
-
-    // Promise.all(successfulL1Deposits.map(getL2TxnHashes))
-    //   .then(txnHashesArr => {
-    //     const transactionsToAdd: Transaction[] = []
-
-    //     const txIdsSet = new Set([...sortedTransactions.map(tx => tx.txID)])
-
-    //     successfulL1Deposits.forEach((depositTxn: Transaction, i: number) => {
-    //       const txnHashes = txnHashesArr[i]
-    //       if (txnHashes === null) {
-    //         console.log('Could not find seqNum for', depositTxn.txID)
-    //         return
-    //       }
-    //       const { retryableTicketHash, autoRedeemHash, userTxnHash } = txnHashes
-    //       const seqNum = txnHashes.seqNum.toNumber()
-    //       // add ticket creation if not yet included
-    //       if (!txIdsSet.has(retryableTicketHash)) {
-    //         transactionsToAdd.push({
-    //           ...depositTxn,
-    //           ...{
-    //             status: 'pending',
-    //             type:
-    //               depositTxn.assetType === 'ETH'
-    //                 ? 'deposit-l2'
-    //                 : 'deposit-l2-ticket-created',
-    //             txID: retryableTicketHash,
-    //             seqNum,
-    //             blockNumber: undefined
-    //           }
-    //         })
-    //       }
-
-    //       if (depositTxn.assetType === AssetType.ERC20) {
-    //         // add autoredeem if not yet included (tokens only)
-    //         if (!txIdsSet.has(autoRedeemHash)) {
-    //           transactionsToAdd.push({
-    //             ...depositTxn,
-    //             ...{
-    //               status: 'pending',
-    //               type: 'deposit-l2-auto-redeem',
-    //               txID: autoRedeemHash,
-    //               seqNum,
-    //               blockNumber: undefined
-    //             }
-    //           })
-    //         }
-    //         // add user-txn if not yet included (tokens only)
-    //         if (!txIdsSet.has(userTxnHash)) {
-    //           transactionsToAdd.push({
-    //             ...depositTxn,
-    //             ...{
-    //               status: 'pending',
-    //               type: 'deposit-l2',
-    //               txID: userTxnHash,
-    //               seqNum,
-    //               blockNumber: undefined
-    //             }
-    //           })
-    //         }
-    //       }
-    //     })
-    //     arbTokenBridge?.transactions?.addTransactions(transactionsToAdd)
-    //   })
-    //   .catch(err => {
-    //     console.warn('Errors checking to retryable txns to add', err)
-    //   })
   }, [bridge, arbTokenBridge?.transactions?.addTransactions])
 
   const { forceTrigger: forceTriggerUpdate } = useInterval(

--- a/packages/arb-token-bridge-ui/src/state/app/actions.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/actions.ts
@@ -109,3 +109,7 @@ export const l1DepositsWithUntrackedL2Messages = ({ state }: Context) => {
 export const getSortedTransactions = ({ state }: Context) => {
   return state.app.sortedTransactions
 }
+
+export const getFailedRetryablesToRedeem = ({ state }: Context) => {
+  return state.app.failedRetryablesToRedeem
+}

--- a/packages/arb-token-bridge-ui/src/state/app/actions.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/actions.ts
@@ -102,8 +102,8 @@ export const getPendingTransactions = ({ state }: Context) => {
   return state.app.pendingTransactions
 }
 
-export const getSuccessfulL1Deposits = ({ state }: Context) => {
-  return state.app.successfulL1Deposits
+export const l1DepositsWithUntrackedL2Messages = ({ state }: Context) => {
+  return state.app.l1DepositsWithUntrackedL2Messages
 }
 
 export const getSortedTransactions = ({ state }: Context) => {

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -151,7 +151,9 @@ export const defaultState: AppState = {
     return s.sortedTransactions.filter(
       (txn: Transaction) =>
         (txn.type === 'deposit' || txn.type === 'deposit-l1') &&
-        txn.status === 'success'
+        txn.status === 'success' && (
+          !txn.l1ToL2MsgData || (txn.l1ToL2MsgData.status === L1ToL2MessageStatus.NOT_YET_CREATED && !txn.l1ToL2MsgData.fetchingUpdate)
+        )
     )
   }),
   depositsTransformed: derived((s: AppState) => {

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -73,7 +73,6 @@ export type AppState = {
   withdrawalsTransformed: MergedTransaction[]
   mergedTransactions: MergedTransaction[]
   mergedTransactionsToShow: MergedTransaction[]
-  seqNumToAutoRedeems: SeqNumToTxn
   currentL1BlockNumber: number
 
   networkDetails: Network | null
@@ -214,17 +213,6 @@ export const defaultState: AppState = {
       }
       return true
     })
-  }),
-  seqNumToAutoRedeems: derived((s: AppState) => {
-    const seqNumToTicketCreation: SeqNumToTxn = {}
-
-    s.mergedTransactions.forEach(txn => {
-      const { seqNum, direction } = txn
-      if (direction === 'deposit-l2-auto-redeem' && seqNum) {
-        seqNumToTicketCreation[seqNum as number] = txn
-      }
-    })
-    return seqNumToTicketCreation
   }),
   currentL1BlockNumber: 0,
 

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -110,6 +110,7 @@ export type AppState = {
   sortedTransactions: Transaction[]
   pendingTransactions: Transaction[]
   l1DepositsWithUntrackedL2Messages: Transaction[]
+  failedRetryablesToRedeem: MergedTransaction[]
   depositsTransformed: MergedTransaction[]
   withdrawalsTransformed: MergedTransaction[]
   mergedTransactions: MergedTransaction[]
@@ -155,6 +156,11 @@ export const defaultState: AppState = {
         (!txn.l1ToL2MsgData ||
           (txn.l1ToL2MsgData.status === L1ToL2MessageStatus.NOT_YET_CREATED &&
             !txn.l1ToL2MsgData.fetchingUpdate))
+    )
+  }),
+  failedRetryablesToRedeem: derived((s: AppState) => {
+    return s.depositsTransformed.filter(
+      tx => tx.depositStatus === DepositStatus.L2_FAILURE
     )
   }),
   depositsTransformed: derived((s: AppState) => {

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -68,7 +68,7 @@ const getDepositStatus = (tx: Transaction) => {
 
 export interface MergedTransaction {
   direction: TxnType
-  status: string // todo: this is kind of all over the place r.n
+  status: string 
   createdAtTime: number | null
   createdAt: string | null
   resolvedAt: string | null
@@ -109,7 +109,7 @@ export type AppState = {
   isDepositMode: boolean
   sortedTransactions: Transaction[]
   pendingTransactions: Transaction[]
-  successfulL1Deposits: Transaction[]
+  l1DepositsWithUntrackedL2Messages: Transaction[]
   depositsTransformed: MergedTransaction[]
   withdrawalsTransformed: MergedTransaction[]
   mergedTransactions: MergedTransaction[]
@@ -146,7 +146,7 @@ export const defaultState: AppState = {
   pendingTransactions: derived((s: AppState) => {
     return s.sortedTransactions.filter(tx => tx.status === 'pending')
   }),
-  successfulL1Deposits: derived((s: AppState) => {
+  l1DepositsWithUntrackedL2Messages: derived((s: AppState) => {
     // check 'deposit' and 'deposit-l1' for backwards compatibility with old client side cache
     return s.sortedTransactions.filter(
       (txn: Transaction) =>

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -68,7 +68,7 @@ const getDepositStatus = (tx: Transaction) => {
 
 export interface MergedTransaction {
   direction: TxnType
-  status: string 
+  status: string
   createdAtTime: number | null
   createdAt: string | null
   resolvedAt: string | null
@@ -151,9 +151,10 @@ export const defaultState: AppState = {
     return s.sortedTransactions.filter(
       (txn: Transaction) =>
         (txn.type === 'deposit' || txn.type === 'deposit-l1') &&
-        txn.status === 'success' && (
-          !txn.l1ToL2MsgData || (txn.l1ToL2MsgData.status === L1ToL2MessageStatus.NOT_YET_CREATED && !txn.l1ToL2MsgData.fetchingUpdate)
-        )
+        txn.status === 'success' &&
+        (!txn.l1ToL2MsgData ||
+          (txn.l1ToL2MsgData.status === L1ToL2MessageStatus.NOT_YET_CREATED &&
+            !txn.l1ToL2MsgData.fetchingUpdate))
     )
   }),
   depositsTransformed: derived((s: AppState) => {

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -11,7 +11,8 @@ import {
   Transaction,
   TxnType,
   OutgoingMessageState,
-  NodeBlockDeadlineStatus
+  NodeBlockDeadlineStatus,
+  L1ToL2MessageData
 } from 'token-bridge-sdk'
 
 import { ConnectionState, PendingWithdrawalsLoadedState } from '../../util'
@@ -40,6 +41,7 @@ export interface MergedTransaction {
   tokenAddress: string | null
   seqNum?: number
   nodeBlockDeadline?: NodeBlockDeadlineStatus
+  l1ToL2MsgData?:  L1ToL2MessageData
 }
 
 export interface WarningTokens {
@@ -133,7 +135,8 @@ export const defaultState: AppState = {
         isWithdrawal: false,
         blockNum: tx.blockNumber || null,
         tokenAddress: null, // not needed
-        seqNum: tx.seqNum
+        seqNum: tx.seqNum,
+        l1ToL2MsgData: tx.l1ToL2MsgData
       }
     })
     return deposits

--- a/packages/token-bridge-sdk/package.json
+++ b/packages/token-bridge-sdk/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.4.10",
-    "@arbitrum/sdk": "^1.0.0",
+    "@arbitrum/sdk": "^1.0.1",
     "@rehooks/local-storage": "^2.3.0",
     "@types/lodash.isempty": "^4.4.6",
     "@uniswap/token-lists": "^1.0.0-beta.27",

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -2,6 +2,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { L2ToL1EventResult, OutgoingMessageState } from 'arb-ts'
 import { BigNumber, ContractReceipt, ethers, Signer } from 'ethers'
 import { TokenList } from '@uniswap/token-lists'
+import { L1ToL2Message } from '@arbitrum/sdk'
 
 import {
   FailedTransaction,
@@ -144,6 +145,7 @@ export interface TransactionActions {
     tx?: ethers.ContractTransaction,
     seqNum?: number
   ) => void
+  addL1ToL2MsgToDepositTxn: (txID: string, l1ToL2Msg: L1ToL2Message) => void
 }
 
 export type ArbTokenBridgeTransactions = {
@@ -155,6 +157,7 @@ export type ArbTokenBridgeTransactions = {
   | 'setTransactionConfirmed'
   | 'updateTransaction'
   | 'addTransactions'
+  | 'addL1ToL2MsgToDepositTxn'
 >
 
 export interface ArbTokenBridge {

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -2,7 +2,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { L2ToL1EventResult, OutgoingMessageState } from 'arb-ts'
 import { BigNumber, ContractReceipt, ethers, Signer } from 'ethers'
 import { TokenList } from '@uniswap/token-lists'
-import { L1ToL2Message } from '@arbitrum/sdk'
+import { L1ToL2MessageReader } from '@arbitrum/sdk'
 
 import {
   FailedTransaction,
@@ -145,7 +145,10 @@ export interface TransactionActions {
     tx?: ethers.ContractTransaction,
     seqNum?: number
   ) => void
-  addL1ToL2MsgToDepositTxn: (txID: string, l1ToL2Msg: L1ToL2Message) => void
+  addL1ToL2MsgToDepositTxn: (
+    txID: string,
+    l1ToL2Msg: L1ToL2MessageReader
+  ) => void
 }
 
 export type ArbTokenBridgeTransactions = {

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -167,8 +167,6 @@ export interface ArbTokenBridge {
   cache: ArbTokenBridgeCache
   eth: ArbTokenBridgeEth
   token: ArbTokenBridgeToken
-  arbSigner: Signer
-  l1Signer: Signer
   transactions: ArbTokenBridgeTransactions
   pendingWithdrawalsMap: PendingWithdrawalsMap
   setInitialPendingWithdrawals: (

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -2,7 +2,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { L2ToL1EventResult, OutgoingMessageState } from 'arb-ts'
 import { BigNumber, ContractReceipt, ethers, Signer } from 'ethers'
 import { TokenList } from '@uniswap/token-lists'
-import { L1ToL2MessageReader } from '@arbitrum/sdk'
+import { L1ToL2MessageReader, L1ToL2MessageStatus } from '@arbitrum/sdk'
 
 import {
   FailedTransaction,
@@ -145,7 +145,11 @@ export interface TransactionActions {
     tx?: ethers.ContractTransaction,
     seqNum?: number
   ) => void
-  updateL1ToL2MsgData: (txID: string, l1ToL2Msg: L1ToL2MessageReader) => void
+  updateL1ToL2MsgData: (
+    txID: string,
+    l1ToL2Msg: L1ToL2MessageReader,
+    status?: L1ToL2MessageStatus
+  ) => void
 }
 
 export type ArbTokenBridgeTransactions = {

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -145,10 +145,7 @@ export interface TransactionActions {
     tx?: ethers.ContractTransaction,
     seqNum?: number
   ) => void
-  addL1ToL2MsgToDepositTxn: (
-    txID: string,
-    l1ToL2Msg: L1ToL2MessageReader
-  ) => void
+  updateL1ToL2MsgData: (txID: string, l1ToL2Msg: L1ToL2MessageReader) => void
 }
 
 export type ArbTokenBridgeTransactions = {
@@ -160,7 +157,7 @@ export type ArbTokenBridgeTransactions = {
   | 'setTransactionConfirmed'
   | 'updateTransaction'
   | 'addTransactions'
-  | 'addL1ToL2MsgToDepositTxn'
+  | 'updateL1ToL2MsgData'
 >
 
 export interface ArbTokenBridge {

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -167,7 +167,7 @@ export interface ArbTokenBridge {
   cache: ArbTokenBridgeCache
   eth: ArbTokenBridgeEth
   token: ArbTokenBridgeToken
-  arbSigner: Signer 
+  arbSigner: Signer
   l1Signer: Signer
   transactions: ArbTokenBridgeTransactions
   pendingWithdrawalsMap: PendingWithdrawalsMap

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -167,7 +167,8 @@ export interface ArbTokenBridge {
   cache: ArbTokenBridgeCache
   eth: ArbTokenBridgeEth
   token: ArbTokenBridgeToken
-  arbSigner: Signer
+  arbSigner: Signer 
+  l1Signer: Signer
   transactions: ArbTokenBridgeTransactions
   pendingWithdrawalsMap: PendingWithdrawalsMap
   setInitialPendingWithdrawals: (

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -170,7 +170,7 @@ export const useArbTokenBridge = (
       updateTransaction,
       removeTransaction,
       addFailedTransaction,
-      addL1ToL2MsgToDepositTxn
+      updateL1ToL2MsgData
     }
   ] = useTransactions()
 
@@ -1358,7 +1358,7 @@ export const useArbTokenBridge = (
       updateTransaction,
       addTransaction,
       addTransactions,
-      addL1ToL2MsgToDepositTxn
+      updateL1ToL2MsgData
     },
     pendingWithdrawalsMap: pendingWithdrawalsMap,
     setInitialPendingWithdrawals: setInitialPendingWithdrawals

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -1351,6 +1351,7 @@ export const useArbTokenBridge = (
       triggerOutbox: triggerOutboxToken
     },
     arbSigner: bridge.l2Bridge.l2Signer,
+    l1Signer: l1.signer,
     transactions: {
       transactions,
       clearPendingTransactions,

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -1384,8 +1384,6 @@ export const useArbTokenBridge = (
       withdraw: withdrawToken,
       triggerOutbox: triggerOutboxToken
     },
-    arbSigner: bridge.l2Bridge.l2Signer,
-    l1Signer: l1.signer,
     transactions: {
       transactions,
       clearPendingTransactions,

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -169,7 +169,8 @@ export const useArbTokenBridge = (
       setTransactionConfirmed,
       updateTransaction,
       removeTransaction,
-      addFailedTransaction
+      addFailedTransaction,
+      addL1ToL2MsgToDepositTxn
     }
   ] = useTransactions()
 
@@ -1356,7 +1357,8 @@ export const useArbTokenBridge = (
       setTransactionConfirmed,
       updateTransaction,
       addTransaction,
-      addTransactions
+      addTransactions,
+      addL1ToL2MsgToDepositTxn
     },
     pendingWithdrawalsMap: pendingWithdrawalsMap,
     setInitialPendingWithdrawals: setInitialPendingWithdrawals

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -56,7 +56,7 @@ export const txnTypeToLayer = (txnType: TxnType): 1 | 2 => {
 export interface L1ToL2MessageData {
   status: L1ToL2MessageStatus
   retryableCreationTxID: string
-  l2TxID: string,
+  l2TxID: string
   fetchingUpdate: boolean
 }
 type TransactionBase = {
@@ -229,13 +229,9 @@ function reducer(state: Transaction[], action: Action) {
 
 const localStorageReducer = (state: Transaction[], action: Action) => {
   const newState = reducer(state, action)
-  // don't cache fetchingUpdate state 
-  console.warn('newState', newState);
-  
-  const stateForCache = newState.map((tx)=>{
-    console.warn('tx', tx);
-    
-    if(tx.l1ToL2MsgData && tx.l1ToL2MsgData.fetchingUpdate){
+  // don't cache fetchingUpdate state
+  const stateForCache = newState.map(tx => {
+    if (tx.l1ToL2MsgData && tx.l1ToL2MsgData.fetchingUpdate) {
       return {
         ...tx,
         l1ToL2MsgData: {
@@ -317,10 +313,10 @@ const useTransactions = (): [Transaction[], TransactionActions] => {
     })
 
     if (shouldFetchUpdate) {
-      console.warn('XXXX waiting for status')
+      console.info('waiting for L1toL2Msg status for', txID)
 
       l1ToL2Msg.waitForStatus().then(({ status }) => {
-        console.warn('XXXXX status arrived, dispatching update', status)
+        console.info(`1toL2Msg status arrived for ${txID}, dispatching update`,status)
 
         dispatch({
           type: 'UPDATE_L1TOL2MSG_DATA',

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -16,7 +16,7 @@ type Action =
   | { type: 'SET_RESOLVED_TIMESTAMP'; txID: string; timestamp?: string }
   | { type: 'ADD_TRANSACTIONS'; transactions: Transaction[] }
   | {
-      type: 'ADD_L1TOL2MSG_TO_DEPOSIT_TRANSACTION'
+      type: 'UPDATE_L1TOL2MSG_DATA'
       txID: string
       l1ToL2MsgData: L1ToL2MessageData
     }
@@ -219,7 +219,7 @@ function reducer(state: Transaction[], action: Action) {
     case 'SET_RESOLVED_TIMESTAMP': {
       return updateResolvedTimestamp(state, action.txID, action.timestamp)
     }
-    case 'ADD_L1TOL2MSG_TO_DEPOSIT_TRANSACTION': {
+    case 'UPDATE_L1TOL2MSG_DATA': {
       return updateTxnL1ToL2Msg(state, action.txID, action.l1ToL2MsgData)
     }
     default:
@@ -306,7 +306,7 @@ const useTransactions = (): [Transaction[], TransactionActions] => {
     const status = await l1ToL2Msg.status()
     const shouldFetchUpdate = status === L1ToL2MessageStatus.NOT_YET_CREATED
     dispatch({
-      type: 'ADD_L1TOL2MSG_TO_DEPOSIT_TRANSACTION',
+      type: 'UPDATE_L1TOL2MSG_DATA',
       txID: txID,
       l1ToL2MsgData: {
         status,
@@ -323,7 +323,7 @@ const useTransactions = (): [Transaction[], TransactionActions] => {
         console.warn('XXXXX status arrived, dispatching update', status)
 
         dispatch({
-          type: 'ADD_L1TOL2MSG_TO_DEPOSIT_TRANSACTION', // todo; can be one thing
+          type: 'UPDATE_L1TOL2MSG_DATA',
           txID,
           l1ToL2MsgData: {
             status,

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -316,7 +316,10 @@ const useTransactions = (): [Transaction[], TransactionActions] => {
       console.info('waiting for L1toL2Msg status for', txID)
 
       l1ToL2Msg.waitForStatus().then(({ status }) => {
-        console.info(`1toL2Msg status arrived for ${txID}, dispatching update`,status)
+        console.info(
+          `1toL2Msg status arrived for ${txID}, dispatching update`,
+          status
+        )
 
         dispatch({
           type: 'UPDATE_L1TOL2MSG_DATA',

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -140,10 +140,6 @@ function updateTxnL1ToL2Msg(
     return state
   }
   const tx = newState[index]
-  // if (tx.l1ToL2MsgData) {
-  //   console.warn(`l1tol2msg for ${txID} already added`)
-  //   return state
-  // }
 
   if (!(tx.type === 'deposit' || tx.type === 'deposit-l1')) {
     throw new Error(

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -62,7 +62,7 @@ export const txnTypeToLayer = (txnType: TxnType): 1 | 2 => {
   }
 }
 
-interface L1ToL2MessageData {
+export interface L1ToL2MessageData {
   l1ToL2Msg?: L1ToL2MessageReader
   status: L1ToL2MessageStatus
 }
@@ -261,10 +261,11 @@ function reducer(state: Transaction[], action: Action) {
 
 const localStorageReducer = (state: Transaction[], action: Action) => {
   const newState = reducer(state, action)
-  const stateForCache = state.forEach(tx => {
+  const stateForCache = state.map(tx => {
     if (tx.l1ToL2MsgData) {
       delete tx.l1ToL2MsgData.l1ToL2Msg
     }
+    return
   })
   window.localStorage.setItem('arbTransactions', JSON.stringify(stateForCache))
   return newState

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -31,12 +31,12 @@ export type TxnStatus = 'pending' | 'success' | 'failure' | 'confirmed'
 export type TxnType =
   | 'deposit'
   | 'deposit-l1'
-  | 'deposit-l2'
+  | 'deposit-l2' // unused; keeping for cache backwrads compatability
   | 'withdraw'
   | 'outbox'
   | 'approve'
-  | 'deposit-l2-auto-redeem'
-  | 'deposit-l2-ticket-created'
+  | 'deposit-l2-auto-redeem' // unused; keeping for cache backwrads compatability
+  | 'deposit-l2-ticket-created' // unused; keeping for cache backwrads compatability
 
 export const txnTypeToLayer = (txnType: TxnType): 1 | 2 => {
   switch (txnType) {

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -293,9 +293,10 @@ const useTransactions = (): [Transaction[], TransactionActions] => {
 
   const updateL1ToL2MsgData = async (
     txID: string,
-    l1ToL2Msg: L1ToL2MessageReader
+    l1ToL2Msg: L1ToL2MessageReader,
+    _status?: L1ToL2MessageStatus
   ) => {
-    const status = await l1ToL2Msg.status()
+    const status = _status || (await l1ToL2Msg.status())
     const shouldFetchUpdate = status === L1ToL2MessageStatus.NOT_YET_CREATED
     dispatch({
       type: 'UPDATE_L1TOL2MSG_DATA',

--- a/packages/token-bridge-sdk/src/index.ts
+++ b/packages/token-bridge-sdk/src/index.ts
@@ -19,6 +19,7 @@ export type {
 } from './hooks/useTransactions'
 
 export { txnTypeToLayer } from './hooks/useTransactions'
+export type { L1ToL2MessageData } from './hooks/useTransactions'
 
 export { OutgoingMessageState, ERC20__factory, Bridge } from 'arb-ts'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     tslib "^2.3.0"
     zen-observable-ts "~1.1.0"
 
-"@arbitrum/sdk@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-1.0.0.tgz#46f247bc8ab58c6ba43ea3c05edc8a76014dba5a"
-  integrity sha512-+KhHgYkDO2r3SgK8Lc+vc/7+g3XFphUOfaZTfpF44cSPEsxB7Fc2E8WQr54rLRLHO1HeqD0kTxIgoQsaTWOH2Q==
+"@arbitrum/sdk@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-1.0.1.tgz#8d654cf4555c43e15cb5a66bda904cabff34965f"
+  integrity sha512-sP1YqP9jPxoqnL+CXmS4wYoE4nNfrVeLons0uT2l9S0g+v/0FrlaCVMCF0lzjouJTY8EJlcUzuxDNg+24Pq7Bg==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"
@@ -2881,6 +2881,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/eslint@^7.2.6":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.0.tgz#7e41f2481d301c68e14f483fe10b017753ce8d5a"
@@ -3223,7 +3228,17 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@typescript-eslint/eslint-plugin@^2.25.0", "@typescript-eslint/eslint-plugin@^4.1.1", "@typescript-eslint/eslint-plugin@^4.24.0", "@typescript-eslint/eslint-plugin@^4.5.0":
+"@typescript-eslint/eslint-plugin@^2.25.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
+  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.34.0"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/eslint-plugin@^4.24.0", "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
   integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
@@ -3236,6 +3251,16 @@
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
+
+"@typescript-eslint/experimental-utils@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
+  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.34.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
 
 "@typescript-eslint/experimental-utils@4.33.0":
   version "4.33.0"
@@ -3272,7 +3297,17 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^2.25.0", "@typescript-eslint/parser@^4.1.1", "@typescript-eslint/parser@^4.24.0", "@typescript-eslint/parser@^4.4.1", "@typescript-eslint/parser@^4.5.0":
+"@typescript-eslint/parser@^2.25.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
+  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.34.0"
+    "@typescript-eslint/typescript-estree" "2.34.0"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/parser@^4.24.0", "@typescript-eslint/parser@^4.4.1", "@typescript-eslint/parser@^4.5.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
   integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
@@ -3312,6 +3347,19 @@
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/typescript-estree@2.34.0":
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
+  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@3.10.1":
   version "3.10.1"
@@ -13923,7 +13971,7 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==


### PR DESCRIPTION
Still some open qs r.e. potential new UX

- [x] Settle on new (?) view / UX for L1 vs L2 msg for deposits
- [x] If "single line" view for deposits, remove unused l2 message types / refactor TransactionsTable rendering
- [x] Ensure backwards compatibility for removed but cached message types
- [x] <s>Add L1ToL2MsgData directly after deposit in useArbTokenBridge hook (i.e., don't only rely on Retryable Includer)</s>
- [x] Have UI handle all L2 message failure states (ticket creation fail, timeout, etc)
- [x] Initiate fetching l2 message status on page load
- [x] Handle retryable ETA