### PR TITLE
refactor(sdk): update methods for retrieving L1 and L2 token data 

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenImportModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenImportModal.tsx
@@ -7,21 +7,15 @@ import {
 } from 'react'
 import Loader from 'react-loader-spinner'
 import Tippy from '@tippyjs/react'
-import { TokenType, ERC20BridgeToken, L1TokenData } from 'token-bridge-sdk'
+import { ERC20BridgeToken } from 'token-bridge-sdk'
 
 import { useActions, useAppState } from '../../state'
 import { Modal } from '../common/Modal'
-import { useTokensFromLists, useTokensFromUser } from './TokenModalUtils'
-
-function toERC20BridgeToken(data: L1TokenData): ERC20BridgeToken {
-  return {
-    name: data.name,
-    type: TokenType.ERC20,
-    symbol: data.symbol,
-    address: data.contract.address,
-    decimals: data.decimals
-  }
-}
+import {
+  useTokensFromLists,
+  useTokensFromUser,
+  toERC20BridgeToken
+} from './TokenModalUtils'
 
 function ModalFooter({
   hideCancel = false,

--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenImportModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenImportModal.tsx
@@ -1,18 +1,15 @@
-import { L1TokenData } from 'arb-ts'
 import {
   useState,
   useEffect,
   useMemo,
   MouseEventHandler,
-  useContext,
   useCallback
 } from 'react'
 import Loader from 'react-loader-spinner'
 import Tippy from '@tippyjs/react'
-import { ERC20BridgeToken, TokenType } from 'token-bridge-sdk'
+import { TokenType, ERC20BridgeToken, L1TokenData } from 'token-bridge-sdk'
 
 import { useActions, useAppState } from '../../state'
-import { BridgeContext } from '../App/App'
 import { Modal } from '../common/Modal'
 import { useTokensFromLists, useTokensFromUser } from './TokenModalUtils'
 
@@ -97,7 +94,6 @@ export function TokenImportModal({
     }
   } = useAppState()
   const actions = useActions()
-  const bridge = useContext(BridgeContext)
 
   const tokensFromUser = useTokensFromUser()
   const tokensFromLists = useTokensFromLists()
@@ -138,19 +134,19 @@ export function TokenImportModal({
 
   const getL1TokenData = useCallback(
     async (eitherL1OrL2Address: string) => {
-      if (!bridge) {
+      if (typeof token === 'undefined') {
         return
       }
 
-      const addressOnL1 = await bridge.getERC20L1Address(eitherL1OrL2Address)
+      const addressOnL1 = await token.getL1ERC20Address(eitherL1OrL2Address)
 
       if (addressOnL1) {
-        return bridge.l1Bridge.getL1TokenData(addressOnL1)
+        return token.getL1TokenData(addressOnL1)
       } else {
-        return bridge.l1Bridge.getL1TokenData(eitherL1OrL2Address)
+        return token.getL1TokenData(eitherL1OrL2Address)
       }
     },
-    [bridge]
+    [token]
   )
 
   const searchForTokenInLists = useCallback(

--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -3,7 +3,6 @@ import { useMedia } from 'react-use'
 import { isAddress, formatUnits } from 'ethers/lib/utils'
 import Loader from 'react-loader-spinner'
 import { AutoSizer, List } from 'react-virtualized'
-import { ERC20BridgeToken, TokenType, L1TokenData } from 'token-bridge-sdk'
 
 import { useActions, useAppState } from '../../state'
 import {
@@ -21,7 +20,8 @@ import TokenConfirmationDialog from './TokenConfirmationDialog'
 import {
   SearchableToken,
   useTokensFromLists,
-  useTokensFromUser
+  useTokensFromUser,
+  toERC20BridgeToken
 } from './TokenModalUtils'
 
 enum Panel {
@@ -291,16 +291,6 @@ export const TokenListBody = () => {
       })}
     </div>
   )
-}
-
-function toERC20BridgeToken(data: L1TokenData): ERC20BridgeToken {
-  return {
-    name: data.name,
-    type: TokenType.ERC20,
-    symbol: data.symbol,
-    address: data.contract.address,
-    decimals: data.decimals
-  }
 }
 
 const ETH_IDENTIFIER = 'eth.address'

--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModal.tsx
@@ -1,18 +1,10 @@
-import React, {
-  FormEventHandler,
-  useMemo,
-  useState,
-  useCallback,
-  useContext
-} from 'react'
+import React, { FormEventHandler, useMemo, useState, useCallback } from 'react'
 import { useMedia } from 'react-use'
 import { isAddress, formatUnits } from 'ethers/lib/utils'
 import Loader from 'react-loader-spinner'
 import { AutoSizer, List } from 'react-virtualized'
-import { L1TokenData } from 'arb-ts'
-import { ERC20BridgeToken, TokenType } from 'token-bridge-sdk'
+import { ERC20BridgeToken, TokenType, L1TokenData } from 'token-bridge-sdk'
 
-import { BridgeContext } from '../App/App'
 import { useActions, useAppState } from '../../state'
 import {
   BRIDGE_TOKEN_LISTS,
@@ -543,7 +535,6 @@ const TokenModal = ({
   const {
     app: { setSelectedToken }
   } = useActions()
-  const bridge = useContext(BridgeContext)
 
   const [currentPanel, setCurrentPanel] = useState(Panel.TOKENS)
 
@@ -571,7 +562,7 @@ const TokenModal = ({
         return
       }
 
-      const data = await bridge?.l1Bridge.getL1TokenData(_token.address)
+      const data = await token?.getL1TokenData(_token.address)
 
       if (data) {
         token.updateTokenData(_token.address)

--- a/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModalUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TokenModal/TokenModalUtils.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { ERC20BridgeToken, TokenType } from 'token-bridge-sdk'
+import { ERC20BridgeToken, L1TokenData, TokenType } from 'token-bridge-sdk'
 
 import { useAppState } from '../../state'
 import { TokenListWithId, useTokenLists } from '../../tokenLists'
@@ -144,4 +144,14 @@ function tokenListsToSearchableTokenStorage(
         return acc
       }, {})
   )
+}
+
+export function toERC20BridgeToken(data: L1TokenData): ERC20BridgeToken {
+  return {
+    name: data.name,
+    type: TokenType.ERC20,
+    symbol: data.symbol,
+    address: data.contract.address,
+    decimals: data.decimals
+  }
 }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useWithdrawOnly.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useWithdrawOnly.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useState, useContext, useCallback, useMemo } from 'react'
-
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { constants } from 'ethers'
-import { ERC20__factory } from 'token-bridge-sdk'
 
 import { useAppState } from '../../state'
-import { BridgeContext } from '../App/App'
 
 const withdrawOnlyTokens = [
   {
@@ -46,33 +43,33 @@ const useWithdrawOnly = () => {
     app: { selectedToken, arbTokenBridge, l1NetworkDetails }
   } = useAppState()
   const [doneAddingTokens, setDoneAddingTokens] = useState(false)
-  const bridge = useContext(BridgeContext)
 
   const addTokens = useCallback(async () => {
-    if (!bridge) return
-    const userAddress = await bridge.l2Signer.getAddress()
     try {
       for (let i = 0; i < withdrawOnlyTokens.length; i += 1) {
         const { l1Address, l2Address } = withdrawOnlyTokens[i]
-        if (!l2Address) continue
-        const token = ERC20__factory.connect(l2Address, bridge.l2Provider)
-        const l2Bal = await token.balanceOf(userAddress)
-        if (!l2Bal.eq(constants.Zero)) {
-          // add it if user has an L2 balance
 
+        if (!l2Address) {
+          continue
+        }
+
+        const { balance } = await arbTokenBridge.token.getL2TokenData(l2Address)
+
+        // add it if user has an L2 balance
+        if (!balance.eq(constants.Zero)) {
           await arbTokenBridge.token.add(l1Address)
         }
       }
     } catch (err) {
       console.warn(err)
     }
-  }, [bridge, arbTokenBridge])
+  }, [arbTokenBridge])
 
   useEffect(() => {
     if (
-      !bridge ||
       !arbTokenBridge ||
       !arbTokenBridge.token ||
+      arbTokenBridge.walletAddress === '' ||
       doneAddingTokens ||
       !(l1NetworkDetails && l1NetworkDetails.chainID === '1')
     )
@@ -80,7 +77,7 @@ const useWithdrawOnly = () => {
     // when ready/ on load, add tokens
     addTokens()
     setDoneAddingTokens(true)
-  }, [bridge, doneAddingTokens, arbTokenBridge])
+  }, [doneAddingTokens, arbTokenBridge])
 
   const shouldDisableDeposit = useMemo(() => {
     if (!selectedToken) return false

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -145,6 +145,8 @@ export interface ArbTokenBridgeToken {
   triggerOutbox: (id: string) => Promise<void | ContractReceipt>
   getL1TokenData: (erc20L1Address: string) => Promise<L1TokenData>
   getL2TokenData: (erc20L2Address: string) => Promise<L2TokenData>
+  getL1ERC20Address: (erc20L2Address: string) => Promise<string | null>
+  getL2ERC20Address: (erc20L1Address: string) => Promise<string>
 }
 
 export interface TransactionActions {

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -143,6 +143,8 @@ export interface ArbTokenBridgeToken {
     amount: BigNumber
   ) => Promise<void | ContractReceipt>
   triggerOutbox: (id: string) => Promise<void | ContractReceipt>
+  getL1TokenData: (erc20L1Address: string) => Promise<L1TokenData>
+  getL2TokenData: (erc20L2Address: string) => Promise<L2TokenData>
 }
 
 export interface TransactionActions {

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -2,6 +2,8 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { L2ToL1EventResult, OutgoingMessageState } from 'arb-ts'
 import { BigNumber, ContractReceipt, ethers, Signer } from 'ethers'
 import { TokenList } from '@uniswap/token-lists'
+import { ERC20 } from '@arbitrum/sdk/dist/lib/abi/ERC20'
+import { StandardArbERC20 } from '@arbitrum/sdk/dist/lib/abi/StandardArbERC20'
 
 import {
   FailedTransaction,
@@ -48,6 +50,20 @@ export enum AssetType {
   ERC20 = 'ERC20',
   ERC721 = 'ERC721',
   ETH = 'ETH'
+}
+
+export interface L1TokenData {
+  name: string
+  symbol: string
+  balance: BigNumber
+  allowance: BigNumber
+  decimals: number
+  contract: ERC20
+}
+
+export interface L2TokenData {
+  balance: BigNumber
+  contract: StandardArbERC20
 }
 
 export interface ContractStorage<T> {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -1441,7 +1441,9 @@ export const useArbTokenBridge = (
       approve: approveToken,
       deposit: depositToken,
       withdraw: withdrawToken,
-      triggerOutbox: triggerOutboxToken
+      triggerOutbox: triggerOutboxToken,
+      getL1TokenData,
+      getL2TokenData
     },
     arbSigner: l2.signer,
     transactions: {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -710,7 +710,8 @@ export const useArbTokenBridge = (
         setERC20Cache(values.filter((val): val is string => !!val))
       })
     }
-    bridge.l1Bridge.getWalletAddress().then(_address => {
+
+    l1.signer.getAddress().then(_address => {
       setWalletAddress(_address)
     })
   }, [])

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -523,7 +523,7 @@ export const useArbTokenBridge = (
         txID: tx.hash,
         assetName: symbol,
         assetType: AssetType.ERC20,
-        sender: await bridge.l2Bridge.getWalletAddress(),
+        sender: await l2.signer.getAddress(),
         blockNumber: tx.blockNumber || 0,
         l1NetworkID
       })

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -307,6 +307,22 @@ export const useArbTokenBridge = (
     )
   }
 
+  /**
+   * Retrieves data about whether an ERC-20 token is disabled on the router.
+   * @param erc20L1Address
+   * @returns
+   */
+  async function l1TokenIsDisabled(erc20L1Address: string): Promise<boolean> {
+    if (typeof l1.signer.provider === 'undefined') {
+      throw new Error(`No provider found for L1 signer`)
+    }
+
+    return new Erc20Bridger(l2.network).l1TokenIsDisabled(
+      erc20L1Address,
+      l1.signer.provider
+    )
+  }
+
   const walletAddressCached = useCallback(async () => {
     if (walletAddress) {
       return walletAddress
@@ -710,7 +726,8 @@ export const useArbTokenBridge = (
       l2Address = undefined
     }
 
-    const isDisabled = await bridge.l1Bridge.tokenIsDisabled(l1Address)
+    const isDisabled = await l1TokenIsDisabled(l1Address)
+
     if (isDisabled) {
       throw new TokenDisabledError('Token currently disabled')
     }

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -187,8 +187,7 @@ export const useArbTokenBridge = (
   const l1NetworkID = useMemo(() => String(l1.network.chainID), [l1.network])
 
   /**
-   * Retrieves data about an ERC-20 token using its L1 address.
-   * Does not throw if the provided address is not a valid ERC-20 token.
+   * Retrieves data about an ERC-20 token using its L1 address. Throws if fails to retrieve balance or allowance.
    * @param erc20L1Address
    * @returns
    */

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -456,9 +456,7 @@ export const useArbTokenBridge = (
           const { symbol, decimals } = bridgeToken
           return { symbol, decimals }
         }
-        const { symbol, decimals } = await bridge.l1Bridge.getL1TokenData(
-          erc20l1Address
-        )
+        const { symbol, decimals } = await getL1TokenData(erc20l1Address)
         addToken(erc20l1Address)
         return { symbol, decimals }
       })()
@@ -747,7 +745,7 @@ export const useArbTokenBridge = (
         return
       }
       const { l2Address } = bridgeToken
-      const l1Data = await bridge.l1Bridge.getL1TokenData(l1Address)
+      const l1Data = await getL1TokenData(l1Address)
       const l2Data =
         (l2Address && (await bridge.l2Bridge.getL2TokenData(l2Address))) ||
         undefined
@@ -848,11 +846,7 @@ export const useArbTokenBridge = (
         true
       )
 
-      const tokenData = await bridge.l1Bridge.getL1TokenData(
-        tokenAddress as string
-      )
-      const symbol = tokenData.symbol
-      const decimals = tokenData.decimals
+      const { symbol, decimals } = await getL1TokenData(tokenAddress as string)
 
       addTransaction({
         status: 'pending',

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -12,10 +12,7 @@ import {
   MultiCaller
 } from '@arbitrum/sdk'
 
-import { ERC20 } from '@arbitrum/sdk/dist/lib/abi/ERC20'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
-
-import { StandardArbERC20 } from '@arbitrum/sdk/dist/lib/abi/StandardArbERC20'
 import { StandardArbERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/StandardArbERC20__factory'
 
 import { Node__factory } from '@arbitrum/sdk/dist/lib/abi/factories/Node__factory'
@@ -34,7 +31,9 @@ import {
   ERC721Balance,
   L2ToL1EventResultPlus,
   PendingWithdrawalsMap,
-  TokenType
+  TokenType,
+  L1TokenData,
+  L2TokenData
 } from './arbTokenBridge.types'
 
 import {
@@ -84,20 +83,6 @@ function getDefaultTokenSymbol(address: string) {
     '...' +
     lowercased.substring(lowercased.length - 3)
   )
-}
-
-export interface L1TokenData {
-  name: string
-  symbol: string
-  balance: BigNumber
-  allowance: BigNumber
-  decimals: number
-  contract: ERC20
-}
-
-export interface L2TokenData {
-  balance: BigNumber
-  contract: StandardArbERC20
 }
 
 export interface TokenBridgeParams {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -1443,7 +1443,9 @@ export const useArbTokenBridge = (
       withdraw: withdrawToken,
       triggerOutbox: triggerOutboxToken,
       getL1TokenData,
-      getL2TokenData
+      getL2TokenData,
+      getL1ERC20Address,
+      getL2ERC20Address
     },
     arbSigner: l2.signer,
     transactions: {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -12,6 +12,7 @@ import {
   MultiCaller
 } from '@arbitrum/sdk'
 
+import { ERC20 } from '@arbitrum/sdk/dist/lib/abi/ERC20'
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 
 import { Node__factory } from '@arbitrum/sdk/dist/lib/abi/factories/Node__factory'
@@ -80,6 +81,15 @@ function getDefaultTokenSymbol(address: string) {
     '...' +
     lowercased.substring(lowercased.length - 3)
   )
+}
+
+export interface L1TokenData {
+  name: string
+  symbol: string
+  balance: BigNumber
+  allowance: BigNumber
+  decimals: number
+  contract: ERC20
 }
 
 export interface TokenBridgeParams {
@@ -182,7 +192,7 @@ export const useArbTokenBridge = (
    * @param erc20L1Address
    * @returns
    */
-  async function getL1TokenData(erc20L1Address: string) {
+  async function getL1TokenData(erc20L1Address: string): Promise<L1TokenData> {
     if (typeof l1.signer.provider === 'undefined') {
       throw new Error(`No provider found for L1 signer`)
     }
@@ -203,6 +213,14 @@ export const useArbTokenBridge = (
       allowance: { owner: walletAddress, spender: l1GatewayAddress },
       decimals: true
     })
+
+    if (typeof tokenData.balance === 'undefined') {
+      throw new Error(`No balance method available`)
+    }
+
+    if (typeof tokenData.allowance === 'undefined') {
+      throw new Error(`No allowance method available`)
+    }
 
     return {
       name: tokenData.name || getDefaultTokenName(erc20L1Address),

--- a/packages/token-bridge-sdk/src/index.ts
+++ b/packages/token-bridge-sdk/src/index.ts
@@ -7,7 +7,9 @@ export type {
   ERC20BridgeToken,
   PendingWithdrawalsMap,
   ContractStorage,
-  NodeBlockDeadlineStatus
+  NodeBlockDeadlineStatus,
+  L1TokenData,
+  L2TokenData
 } from './hooks/arbTokenBridge.types'
 export { TokenType, AssetType } from './hooks/arbTokenBridge.types'
 


### PR DESCRIPTION
In this PR:

- [x] Update `getL1TokenData` so it throws when `balance` or `allowance` are unavailable to match the previous `arb-ts` implementation
  - What should we use as the default value for `decimals`? In `arb-ts` [we used 18](https://github.com/OffchainLabs/arbitrum/blob/master/packages/arb-ts/src/lib/l1Bridge.ts#L202).
- [x] Remove `useCallback` from the `addToken` method, as the dependency list was incomplete which can cause bugs
- [x] Refactor all uses of `l1Bridge.getL1TokenData` to the new `getL1TokenData` method
- [x] Create a new `getL2TokenData` method which matches the previous `arb-ts` implementation
- [x] Refactor all uses of `l2Bridge.getL2TokenData` to the new `getL2TokenData` method
- [x] Create a new `l1TokenIsDisabled` method
- [x] Expose the `getL1TokenData`, `getL2TokenData`, `getL1ERC20Address`, `getL2ERC20Address` methods
- [x] Update `TokenModal` and `TokenImportModal` to use the new methods