### PR TITLE
refactor(sdk): handle network switching

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -261,6 +261,10 @@ const Injector = ({ children }: { children: React.ReactNode }): JSX.Element => {
 
   useEffect(() => {
     if (library) {
+      async function logGasPrice() {
+        console.log('Gas price:', await library?.getGasPrice())
+      }
+
       const changeNetwork = async (chainId: string) => {
         const targetNetwork = networks[chainId]
         if (!targetNetwork) {
@@ -322,6 +326,8 @@ const Injector = ({ children }: { children: React.ReactNode }): JSX.Element => {
           // TODO: reset state so user can attempt to press "Deposit" again
         }
       }
+
+      logGasPrice()
       actions.app.setChangeNetwork(changeNetwork)
     }
   }, [library])

--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -153,7 +153,7 @@ const Injector = ({ children }: { children: React.ReactNode }): JSX.Element => {
   const actions = useActions()
 
   const _networks = useNetworks()
-  const _signers = useSigners()
+  const signers = useSigners()
 
   const [globalBridge, setGlobalBridge] = useState<Bridge | null>(null)
   const [tokenBridgeParams, setTokenBridgeParams] =
@@ -230,21 +230,21 @@ const Injector = ({ children }: { children: React.ReactNode }): JSX.Element => {
       actions.app.setConnectionState(ConnectionState.L2_CONNECTED)
     }
 
-    if (_signers.status !== UseSignersStatus.SUCCESS) {
+    if (signers.status !== UseSignersStatus.SUCCESS) {
       return
     }
 
     initBridge({
       l1: {
-        signer: _signers.data.l1Signer,
+        signer: signers.l1Signer,
         network: l1Network
       },
       l2: {
-        signer: _signers.data.l2Signer,
+        signer: signers.l2Signer,
         network: l2Network
       }
     })
-  }, [_networks, _signers, initBridge])
+  }, [_networks, signers, initBridge])
 
   useEffect(() => {
     axios

--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -216,7 +216,7 @@ const Injector = ({ children }: { children: React.ReactNode }): JSX.Element => {
     const network = isConnectedToArbitrum ? l2Network : l1Network
     const networkId = String(network.chainID)
 
-    // TODO: We're still relying on the old networks. We should switch to @arbitrum/sdk networks.
+    // TODO: Deprecate network utils in favor of @arbitrum/sdk networks
     actions.app.reset(networkId)
     actions.app.setNetworkID(networkId)
 

--- a/packages/arb-token-bridge-ui/src/hooks/useNetworks.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useNetworks.ts
@@ -8,15 +8,27 @@ export enum UseNetworksStatus {
   CONNECTED = 'network_connected'
 }
 
+export type UseNetworksDataUnknown = {
+  l1Network: undefined
+  l2Network: undefined
+  isConnectedToArbitrum: undefined
+}
+
 export type UseNetworksData = {
   l1Network: L1Network
   l2Network: L2Network
   isConnectedToArbitrum: boolean
 }
 
+const defaults: UseNetworksDataUnknown = {
+  l1Network: undefined,
+  l2Network: undefined,
+  isConnectedToArbitrum: undefined
+}
+
 export type UseNetworksResult =
-  | { status: UseNetworksStatus.NOT_CONNECTED; data: undefined }
-  | { status: UseNetworksStatus.NOT_SUPPORTED; data: undefined }
+  | ({ status: UseNetworksStatus.NOT_CONNECTED } & UseNetworksDataUnknown)
+  | ({ status: UseNetworksStatus.NOT_SUPPORTED } & UseNetworksDataUnknown)
   | ({ status: UseNetworksStatus.CONNECTED } & UseNetworksData)
 
 export function useNetworks(): UseNetworksResult {
@@ -24,7 +36,7 @@ export function useNetworks(): UseNetworksResult {
 
   const [result, setResult] = useState<UseNetworksResult>({
     status: UseNetworksStatus.NOT_CONNECTED,
-    data: undefined
+    ...defaults
   })
 
   const updateNetworks = useCallback((networkId: number) => {
@@ -63,7 +75,7 @@ export function useNetworks(): UseNetworksResult {
           .catch(() =>
             setResult({
               status: UseNetworksStatus.NOT_SUPPORTED,
-              data: undefined
+              ...defaults
             })
           )
       })

--- a/packages/arb-token-bridge-ui/src/hooks/useNetworks.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useNetworks.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useWallet } from '@gimmixorg/use-wallet'
+import { L1Network, L2Network, getL1Network, getL2Network } from '@arbitrum/sdk'
+
+export enum UseNetworksStatus {
+  NOT_CONNECTED = 'network_not_connected',
+  NOT_SUPPORTED = 'network_not_supported',
+  CONNECTED = 'network_connected'
+}
+
+export type UseNetworksData =
+  | { network: L1Network; partnerNetwork: L2Network; isArbitrum: false }
+  | { network: L2Network; partnerNetwork: L1Network; isArbitrum: true }
+
+export type UseNetworksResult =
+  | { status: UseNetworksStatus.NOT_CONNECTED }
+  | { status: UseNetworksStatus.NOT_SUPPORTED }
+  | { status: UseNetworksStatus.CONNECTED; data: UseNetworksData }
+
+export function useNetworks(): UseNetworksResult {
+  const { network: networkInfo } = useWallet()
+
+  const [result, setResult] = useState<UseNetworksResult>({
+    status: UseNetworksStatus.NOT_CONNECTED
+  })
+
+  const updateNetworks = useCallback((_networkId: number) => {
+    // Check if the network is an L1 network
+    getL1Network(_networkId)
+      // The network is an L1 network
+      .then(async _network => {
+        // TODO: Handle multiple partner networks
+        const [_partnerNetworkChainId] = _network.partnerChainIDs
+        const _partnerNetwork = await getL2Network(_partnerNetworkChainId)
+
+        setResult({
+          status: UseNetworksStatus.CONNECTED,
+          data: {
+            network: _network,
+            partnerNetwork: _partnerNetwork,
+            isArbitrum: false
+          }
+        })
+      })
+      // The network is not an L1 network
+      .catch(() => {
+        // Check if the network is an L2 network
+        getL2Network(_networkId)
+          // The network is an L2 network
+          .then(async _network => {
+            const _partnerNetworkChainId = _network.partnerChainID
+            const _partnerNetwork = await getL1Network(_partnerNetworkChainId)
+
+            setResult({
+              status: UseNetworksStatus.CONNECTED,
+              data: {
+                network: _network,
+                partnerNetwork: _partnerNetwork,
+                isArbitrum: true
+              }
+            })
+          })
+          // The network is not supported
+          .catch(() => setResult({ status: UseNetworksStatus.NOT_SUPPORTED }))
+      })
+  }, [])
+
+  useEffect(() => {
+    if (typeof networkInfo === 'undefined') {
+      return
+    }
+
+    updateNetworks(networkInfo.chainId)
+  }, [networkInfo, updateNetworks])
+
+  return result
+}

--- a/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
@@ -37,7 +37,10 @@ export function useSigners(): UseSignersResult {
   const { account: address, provider } = useWallet()
 
   return useMemo(() => {
-    if (networks.status === UseNetworksStatus.NOT_CONNECTED) {
+    if (
+      typeof provider === 'undefined' ||
+      networks.status === UseNetworksStatus.NOT_CONNECTED
+    ) {
       return { status: UseSignersStatus.NETWORK_NOT_CONNECTED, ...defaults }
     }
 
@@ -55,13 +58,13 @@ export function useSigners(): UseSignersResult {
       return {
         status: UseSignersStatus.SUCCESS,
         l1Signer: partnerProvider.getSigner(address!),
-        l2Signer: provider?.getSigner(0) as JsonRpcSigner
+        l2Signer: provider.getSigner(0) as JsonRpcSigner
       }
     }
 
     return {
       status: UseSignersStatus.SUCCESS,
-      l1Signer: provider?.getSigner(0) as JsonRpcSigner,
+      l1Signer: provider.getSigner(0) as JsonRpcSigner,
       l2Signer: partnerProvider.getSigner(address!)
     }
   }, [networks, address, provider])

--- a/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
@@ -4,6 +4,7 @@ import { providers } from 'ethers'
 import { JsonRpcSigner } from '@ethersproject/providers/lib/json-rpc-provider'
 
 import { useNetworks, UseNetworksStatus } from './useNetworks'
+import { rpcURLs } from '../util/networks'
 
 export enum UseSignersStatus {
   NETWORK_NOT_CONNECTED = 'network_not_connected',
@@ -36,7 +37,9 @@ export function useSigners(): UseSignersResult {
 
     const { l1Network, l2Network, isConnectedToArbitrum } = networks
     const partnerNetwork = isConnectedToArbitrum ? l1Network : l2Network
-    const partnerProvider = new providers.JsonRpcProvider(partnerNetwork.rpcURL)
+    const partnerProvider = new providers.JsonRpcProvider(
+      partnerNetwork.rpcURL || rpcURLs[partnerNetwork.chainID]
+    )
 
     if (isConnectedToArbitrum) {
       return {

--- a/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useWallet } from '@gimmixorg/use-wallet'
+import { providers } from 'ethers'
+import { JsonRpcSigner } from '@ethersproject/providers/lib/json-rpc-provider'
+
+import { L1Network, L2Network, getL1Network, getL2Network } from '@arbitrum/sdk'
+
+type UseSignersError = 'network_not_connected' | 'network_not_supported'
+type UseSignersResult =
+  | {
+      error: UseSignersError
+    }
+  | {
+      error: false
+      l1Signer: JsonRpcSigner
+      l2Signer: JsonRpcSigner
+    }
+
+enum UseSignersNetworksError {
+  NOT_CONNECTED,
+  NOT_SUPPORTED
+}
+type UseSignersNetworks =
+  | UseSignersNetworksError.NOT_CONNECTED
+  | UseSignersNetworksError.NOT_SUPPORTED
+  | {
+      network: L1Network
+      partnerNetwork: L2Network
+      isArbitrum: false
+    }
+  | {
+      network: L2Network
+      partnerNetwork: L1Network
+      isArbitrum: true
+    }
+
+export function useSigners(): UseSignersResult {
+  const { account: address, provider, network: networkInfo } = useWallet()
+
+  const [networks, setNetworks] = useState<UseSignersNetworks>(
+    UseSignersNetworksError.NOT_CONNECTED
+  )
+
+  const updateNetworks = useCallback((_networkId: number) => {
+    // Check if the network is an L1 network
+    getL1Network(_networkId)
+      // The network is an L1 network
+      .then(async _network => {
+        // TODO: Handle multiple partner networks
+        const [_partnerNetworkChainId] = _network.partnerChainIDs
+        const _partnerNetwork = await getL2Network(_partnerNetworkChainId)
+
+        setNetworks({
+          network: _network,
+          partnerNetwork: _partnerNetwork,
+          isArbitrum: false
+        })
+      })
+      // The network is not an L1 network
+      .catch(() => {
+        // Check if the network is an L2 network
+        getL2Network(_networkId)
+          // The network is an L2 network
+          .then(async _network => {
+            const _partnerNetworkChainId = _network.partnerChainID
+            const _partnerNetwork = await getL1Network(_partnerNetworkChainId)
+
+            setNetworks({
+              network: _network,
+              partnerNetwork: _partnerNetwork,
+              isArbitrum: true
+            })
+          })
+          // The network is not supported
+          .catch(() => setNetworks(UseSignersNetworksError.NOT_SUPPORTED))
+      })
+  }, [])
+
+  useEffect(() => {
+    if (typeof networkInfo === 'undefined') {
+      return
+    }
+
+    updateNetworks(networkInfo.chainId)
+  }, [networkInfo, updateNetworks])
+
+  return useMemo(() => {
+    if (networks === UseSignersNetworksError.NOT_CONNECTED) {
+      return { error: 'network_not_connected' }
+    }
+
+    if (networks === UseSignersNetworksError.NOT_SUPPORTED) {
+      return { error: 'network_not_supported' }
+    }
+
+    const partnerProvider = new providers.JsonRpcProvider(
+      networks.partnerNetwork.rpcURL
+    )
+
+    if (networks.isArbitrum) {
+      return {
+        error: false,
+        l1Signer: partnerProvider.getSigner(address!),
+        l2Signer: provider?.getSigner(0) as JsonRpcSigner
+      }
+    }
+
+    return {
+      error: false,
+      l1Signer: provider?.getSigner(0) as JsonRpcSigner,
+      l2Signer: partnerProvider.getSigner(address!)
+    }
+  }, [address, provider, networks])
+}

--- a/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
@@ -34,10 +34,11 @@ export function useSigners(): UseSignersResult {
       return { status: UseSignersStatus.NETWORK_NOT_SUPPORTED }
     }
 
-    const { partnerNetwork, isArbitrum } = networks.data
+    const { l1Network, l2Network, isConnectedToArbitrum } = networks
+    const partnerNetwork = isConnectedToArbitrum ? l1Network : l2Network
     const partnerProvider = new providers.JsonRpcProvider(partnerNetwork.rpcURL)
 
-    if (isArbitrum) {
+    if (isConnectedToArbitrum) {
       return {
         status: UseSignersStatus.SUCCESS,
         data: {

--- a/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useSigners.ts
@@ -1,114 +1,58 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useWallet } from '@gimmixorg/use-wallet'
 import { providers } from 'ethers'
 import { JsonRpcSigner } from '@ethersproject/providers/lib/json-rpc-provider'
 
-import { L1Network, L2Network, getL1Network, getL2Network } from '@arbitrum/sdk'
+import { useNetworks, UseNetworksStatus } from './useNetworks'
 
-type UseSignersError = 'network_not_connected' | 'network_not_supported'
-type UseSignersResult =
-  | {
-      error: UseSignersError
-    }
-  | {
-      error: false
-      l1Signer: JsonRpcSigner
-      l2Signer: JsonRpcSigner
-    }
-
-enum UseSignersNetworksError {
-  NOT_CONNECTED,
-  NOT_SUPPORTED
+export enum UseSignersStatus {
+  NETWORK_NOT_CONNECTED = 'network_not_connected',
+  NETWORK_NOT_SUPPORTED = 'network_not_supported',
+  SUCCESS = 'success'
 }
-type UseSignersNetworks =
-  | UseSignersNetworksError.NOT_CONNECTED
-  | UseSignersNetworksError.NOT_SUPPORTED
-  | {
-      network: L1Network
-      partnerNetwork: L2Network
-      isArbitrum: false
-    }
-  | {
-      network: L2Network
-      partnerNetwork: L1Network
-      isArbitrum: true
-    }
+
+export type UseSignersData = {
+  l1Signer: JsonRpcSigner
+  l2Signer: JsonRpcSigner
+}
+
+export type UseSignersResult =
+  | { status: UseSignersStatus.NETWORK_NOT_CONNECTED }
+  | { status: UseSignersStatus.NETWORK_NOT_SUPPORTED }
+  | { status: UseSignersStatus.SUCCESS; data: UseSignersData }
 
 export function useSigners(): UseSignersResult {
-  const { account: address, provider, network: networkInfo } = useWallet()
-
-  const [networks, setNetworks] = useState<UseSignersNetworks>(
-    UseSignersNetworksError.NOT_CONNECTED
-  )
-
-  const updateNetworks = useCallback((_networkId: number) => {
-    // Check if the network is an L1 network
-    getL1Network(_networkId)
-      // The network is an L1 network
-      .then(async _network => {
-        // TODO: Handle multiple partner networks
-        const [_partnerNetworkChainId] = _network.partnerChainIDs
-        const _partnerNetwork = await getL2Network(_partnerNetworkChainId)
-
-        setNetworks({
-          network: _network,
-          partnerNetwork: _partnerNetwork,
-          isArbitrum: false
-        })
-      })
-      // The network is not an L1 network
-      .catch(() => {
-        // Check if the network is an L2 network
-        getL2Network(_networkId)
-          // The network is an L2 network
-          .then(async _network => {
-            const _partnerNetworkChainId = _network.partnerChainID
-            const _partnerNetwork = await getL1Network(_partnerNetworkChainId)
-
-            setNetworks({
-              network: _network,
-              partnerNetwork: _partnerNetwork,
-              isArbitrum: true
-            })
-          })
-          // The network is not supported
-          .catch(() => setNetworks(UseSignersNetworksError.NOT_SUPPORTED))
-      })
-  }, [])
-
-  useEffect(() => {
-    if (typeof networkInfo === 'undefined') {
-      return
-    }
-
-    updateNetworks(networkInfo.chainId)
-  }, [networkInfo, updateNetworks])
+  const networks = useNetworks()
+  const { account: address, provider } = useWallet()
 
   return useMemo(() => {
-    if (networks === UseSignersNetworksError.NOT_CONNECTED) {
-      return { error: 'network_not_connected' }
+    if (networks.status === UseNetworksStatus.NOT_CONNECTED) {
+      return { status: UseSignersStatus.NETWORK_NOT_CONNECTED }
     }
 
-    if (networks === UseSignersNetworksError.NOT_SUPPORTED) {
-      return { error: 'network_not_supported' }
+    if (networks.status === UseNetworksStatus.NOT_SUPPORTED) {
+      return { status: UseSignersStatus.NETWORK_NOT_SUPPORTED }
     }
 
-    const partnerProvider = new providers.JsonRpcProvider(
-      networks.partnerNetwork.rpcURL
-    )
+    const { partnerNetwork, isArbitrum } = networks.data
+    const partnerProvider = new providers.JsonRpcProvider(partnerNetwork.rpcURL)
 
-    if (networks.isArbitrum) {
+    if (isArbitrum) {
       return {
-        error: false,
-        l1Signer: partnerProvider.getSigner(address!),
-        l2Signer: provider?.getSigner(0) as JsonRpcSigner
+        status: UseSignersStatus.SUCCESS,
+        data: {
+          l1Signer: partnerProvider.getSigner(address!),
+          l2Signer: provider?.getSigner(0) as JsonRpcSigner
+        }
       }
     }
 
     return {
-      error: false,
-      l1Signer: provider?.getSigner(0) as JsonRpcSigner,
-      l2Signer: partnerProvider.getSigner(address!)
+      status: UseSignersStatus.SUCCESS,
+      data: {
+        l1Signer: provider?.getSigner(0) as JsonRpcSigner,
+        l2Signer: partnerProvider.getSigner(address!)
+      }
     }
-  }, [address, provider, networks])
+  }, [networks, address, provider])
 }

--- a/packages/arb-token-bridge-ui/src/util/index.ts
+++ b/packages/arb-token-bridge-ui/src/util/index.ts
@@ -1,7 +1,5 @@
 export enum ConnectionState {
   LOADING,
-  NO_METAMASK,
-  WRONG_NETWORK,
   L1_CONNECTED,
   L2_CONNECTED,
   SEQUENCER_UPDATE,

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -112,4 +112,9 @@ const networks: Networks = {
   }
 }
 
+export const rpcURLs: { [chainId: number]: string } = {
+  1: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
+  4: `https://rinkeby.infura.io/v3/${INFURA_KEY}`
+}
+
 export default networks


### PR DESCRIPTION
In this PR:
- [x] Created a new `useNetworks` hook which listens to network changes, and gives information about _if_ and _which_ networks are connected
  - `const { status, l1Network, l2Network, isConnectedToArbitrum } = useNetworks()`
  - The idea is to switch to this hook to be the source of truth for data on the networks, instead of keeping it in a global state
- [x] Created a new `useSigners` hook which uses `useNetworks` internally and gives information on signers
  - `const { status, l1Signer, l2Signer } = useSigners()`
  - The idea is same as above, have the hook be the source of truth for signers instead of keeping them in a global state
- [x] `useArbTokenBridge` now accepts `walletAddress` as part of the params, instead of being derived inside the hook
- [x] Update network switching logic in `App.tsx` to use the new hooks 