### PR TITLE
Add list of token that require l2 approve

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -318,10 +318,10 @@ const TransferPanel = (): JSX.Element => {
         if (selectedToken) {
           const { decimals } = selectedToken
           const amountRaw = utils.parseUnits(amount, decimals)
-          if (shouldRequireApprove) {
+          if (shouldRequireApprove && selectedToken.l2Address) {
             const allowed = await isAllowedL2(
               bridge,
-              selectedToken.address,
+              selectedToken.l2Address,
               amountRaw
             )
             if (!allowed) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -43,12 +43,13 @@ const isAllowed = async (
 
 const isAllowedL2 = async (
   bridge: Bridge,
+  l1TokenAddress: string,
   l2TokenAddress: string,
   amountNeeded: BigNumber
 ) => {
   const token = ERC20__factory.connect(l2TokenAddress, bridge.l2Provider)
   const walletAddress = await bridge.l2Bridge.getWalletAddress()
-  const gatewayAddress = await bridge.l2Bridge.getGatewayAddress(l2TokenAddress)
+  const gatewayAddress = await bridge.l2Bridge.getGatewayAddress(l1TokenAddress)
   return (await token.allowance(walletAddress, gatewayAddress)).gte(
     amountNeeded
   )
@@ -321,6 +322,7 @@ const TransferPanel = (): JSX.Element => {
           if (shouldRequireApprove && selectedToken.l2Address) {
             const allowed = await isAllowedL2(
               bridge,
+              selectedToken.address,
               selectedToken.l2Address,
               amountRaw
             )

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -325,7 +325,10 @@ const TransferPanel = (): JSX.Element => {
               amountRaw
             )
             if (!allowed) {
-              await latestToken.current.approve(selectedToken.address)
+              await latestToken.current.approveL2(
+                selectedToken.address,
+                selectedToken.l2Address
+              )
             }
           }
           latestToken.current.withdraw(selectedToken.address, amountRaw)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -326,8 +326,7 @@ const TransferPanel = (): JSX.Element => {
             )
             if (!allowed) {
               await latestToken.current.approveL2(
-                selectedToken.address,
-                selectedToken.l2Address
+                selectedToken.address
               )
             }
           }

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/useL2Approve.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/useL2Approve.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState, useContext, useCallback, useMemo } from 'react'
+
+import { constants } from 'ethers'
+import { ERC20__factory } from 'token-bridge-sdk'
+
+import { useAppState } from '../../state'
+import { BridgeContext } from '../App/App'
+
+const L2ApproveTokens = [
+  {
+    l1Address: '0x58b6A8A3302369DAEc383334672404Ee733aB239',
+    l2Address: '0x289ba1701C2F088cf0faf8B3705246331cB8A839'
+  }
+].map(token => {
+  const { l1Address, l2Address } = token
+  return {
+    l1Address: l1Address.toLowerCase(),
+    l2Address: l2Address.toLowerCase()
+  }
+})
+
+const L2ApproveTokensL1Address = L2ApproveTokens.map(t => t.l1Address)
+
+const useL2Approve = () => {
+  const {
+    app: { selectedToken, arbTokenBridge, l1NetworkDetails }
+  } = useAppState()
+  const [doneAddingTokens, setDoneAddingTokens] = useState(false)
+  const bridge = useContext(BridgeContext)
+
+  const addTokens = useCallback(async () => {
+    if (!bridge) return
+    const userAddress = await bridge.l2Signer.getAddress()
+    try {
+      for (let i = 0; i < L2ApproveTokens.length; i += 1) {
+        const { l1Address, l2Address } = L2ApproveTokens[i]
+        if (!l2Address) continue
+        const token = ERC20__factory.connect(l2Address, bridge.l2Provider)
+        const l2Bal = await token.balanceOf(userAddress)
+        if (!l2Bal.eq(constants.Zero)) {
+          // add it if user has an L2 balance
+
+          await arbTokenBridge.token.add(l1Address)
+        }
+      }
+    } catch (err) {
+      console.warn(err)
+    }
+  }, [bridge, arbTokenBridge])
+
+  useEffect(() => {
+    if (
+      !bridge ||
+      !arbTokenBridge ||
+      !arbTokenBridge.token ||
+      doneAddingTokens ||
+      !(l1NetworkDetails && l1NetworkDetails.chainID === '1')
+    )
+      return
+    // when ready/ on load, add tokens
+    addTokens()
+    setDoneAddingTokens(true)
+  }, [bridge, doneAddingTokens, arbTokenBridge])
+
+  const shouldRequireApprove = useMemo(() => {
+    if (!selectedToken) return false
+    return L2ApproveTokensL1Address.includes(
+      selectedToken.address.toLowerCase()
+    )
+  }, [selectedToken])
+
+  return { shouldRequireApprove }
+}
+
+export default useL2Approve

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -118,7 +118,7 @@ export interface ArbTokenBridgeToken {
   removeTokensFromList: (listID: number) => void
   updateTokenData: (l1Address: string) => Promise<void>
   approve: (erc20L1Address: string) => Promise<void>
-  approveL2: (erc20L1Address: string, erc20L2Address: string) => Promise<void>
+  approveL2: (erc20L1Address: string) => Promise<void>
   deposit: (
     erc20Address: string,
     amount: BigNumber

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -118,6 +118,7 @@ export interface ArbTokenBridgeToken {
   removeTokensFromList: (listID: number) => void
   updateTokenData: (l1Address: string) => Promise<void>
   approve: (erc20L1Address: string) => Promise<void>
+  approveL2: (erc20L1Address: string, erc20L2Address: string) => Promise<void>
   deposit: (
     erc20Address: string,
     amount: BigNumber

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -269,7 +269,7 @@ export const useArbTokenBridge = (
     )
     const contract = await ERC20__factory.connect(
       erc20L2Address,
-      bridge.l2Bridge.l2Provider
+      bridge.l2Bridge.l2Signer
     )
     const tx = await contract.functions.approve(gatewayAddress, MaxUint256)
     const tokenData = await bridge.l1Bridge.getL1TokenData(erc20L1Address)

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -265,7 +265,7 @@ export const useArbTokenBridge = (
     const { l2Address } = bridgeToken
     if (l2Address?.toLowerCase() !== erc20L2Address.toLowerCase()) throw new Error('L2 Token mismatch')
     const gatewayAddress = await bridge.l2Bridge.getGatewayAddress(
-      erc20L2Address
+      erc20L1Address
     )
     const contract = await ERC20__factory.connect(
       erc20L2Address,

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -263,7 +263,7 @@ export const useArbTokenBridge = (
       throw new Error('Bridge token not found')
     }
     const { l2Address } = bridgeToken
-    if (l2Address !== erc20L2Address) throw new Error('L2 Token mismatch')
+    if (l2Address?.toLowerCase() !== erc20L2Address.toLowerCase()) throw new Error('L2 Token mismatch')
     const gatewayAddress = await bridge.l2Bridge.getGatewayAddress(
       erc20L2Address
     )

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -256,18 +256,16 @@ export const useArbTokenBridge = (
 
   const approveTokenL2 = async (
     erc20L1Address: string,
-    erc20L2Address: string
   ) => {
     const bridgeToken = bridgeTokens[erc20L1Address]
     if (!bridgeToken) throw new Error('Bridge token not found')
     const { l2Address } = bridgeToken
     if (!l2Address) throw new Error('L2 address not found')
-    if (l2Address.toLowerCase() !== erc20L2Address.toLowerCase()) throw new Error('L2 Token mismatch')
     const gatewayAddress = await bridge.l2Bridge.getGatewayAddress(
       erc20L1Address
     )
     const contract = await ERC20__factory.connect(
-      erc20L2Address,
+      l2Address,
       bridge.l2Bridge.l2Signer
     )
     const tx = await contract.functions.approve(gatewayAddress, MaxUint256)

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { BigNumber, constants, ethers, utils } from 'ethers'
 import { useLocalStorage } from '@rehooks/local-storage'
 import { TokenList } from '@uniswap/token-lists'
+import { MaxUint256 } from '@ethersproject/constants'
 import {
   Bridge,
   OutgoingMessageState,
@@ -245,6 +246,42 @@ export const useArbTokenBridge = (
       assetName: tokenData.symbol,
       assetType: AssetType.ERC20,
       sender: await walletAddressCached(),
+      l1NetworkID: await l1NetworkIDCached()
+    })
+
+    const receipt = await tx.wait()
+    updateTransaction(receipt, tx)
+    updateTokenData(erc20L1Address)
+  }
+
+  const approveTokenL2 = async (
+    erc20L1Address: string,
+    erc20L2Address: string
+  ) => {
+    const bridgeToken = bridgeTokens[erc20L1Address]
+    if (!bridgeToken) {
+      throw new Error('Bridge token not found')
+    }
+    const { l2Address } = bridgeToken
+    if (l2Address !== erc20L2Address) throw new Error('L2 Token mismatch')
+    const gatewayAddress = await bridge.l2Bridge.getGatewayAddress(
+      erc20L2Address
+    )
+    const contract = await ERC20__factory.connect(
+      erc20L2Address,
+      bridge.l2Bridge.l2Provider
+    )
+    const tx = await contract.functions.approve(gatewayAddress, MaxUint256)
+    const tokenData = await bridge.l1Bridge.getL1TokenData(erc20L1Address)
+    addTransaction({
+      type: 'approve-l2',
+      status: 'pending',
+      value: null,
+      txID: tx.hash,
+      assetName: tokenData.symbol,
+      assetType: AssetType.ERC20,
+      sender: await walletAddressCached(),
+      blockNumber: tx.blockNumber || 0,
       l1NetworkID: await l1NetworkIDCached()
     })
 
@@ -1256,6 +1293,7 @@ export const useArbTokenBridge = (
       removeTokensFromList,
       updateTokenData,
       approve: approveToken,
+      approveL2: approveTokenL2,
       deposit: depositToken,
       withdraw: withdrawToken,
       triggerOutbox: triggerOutboxToken

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -259,11 +259,10 @@ export const useArbTokenBridge = (
     erc20L2Address: string
   ) => {
     const bridgeToken = bridgeTokens[erc20L1Address]
-    if (!bridgeToken) {
-      throw new Error('Bridge token not found')
-    }
+    if (!bridgeToken) throw new Error('Bridge token not found')
     const { l2Address } = bridgeToken
-    if (l2Address?.toLowerCase() !== erc20L2Address.toLowerCase()) throw new Error('L2 Token mismatch')
+    if (!l2Address) throw new Error('L2 address not found')
+    if (l2Address.toLowerCase() !== erc20L2Address.toLowerCase()) throw new Error('L2 Token mismatch')
     const gatewayAddress = await bridge.l2Bridge.getGatewayAddress(
       erc20L1Address
     )

--- a/packages/token-bridge-sdk/src/hooks/useTransactions.ts
+++ b/packages/token-bridge-sdk/src/hooks/useTransactions.ts
@@ -33,6 +33,7 @@ export type TxnType =
   | 'connext-withdraw'
   | 'deposit-l2-auto-redeem'
   | 'deposit-l2-ticket-created'
+  | 'approve-l2'
 
 export const txnTypeToLayer = (txnType: TxnType): 1 | 2 => {
   switch (txnType) {
@@ -47,6 +48,7 @@ export const txnTypeToLayer = (txnType: TxnType): 1 | 2 => {
     case 'connext-withdraw':
     case 'deposit-l2-auto-redeem':
     case 'deposit-l2-ticket-created':
+    case 'approve-l2':
       return 2
   }
 }


### PR DESCRIPTION
Using the same setup as withdraw-only token to maintain the list. Implemented the l2 approval logic because the l2bridge in arb-ts does not have it. Tested with LPT up to the approval tx initiation. 