### PR TITLE
fix: l2 gas buffer

### DIFF
--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -452,7 +452,10 @@ export const useArbTokenBridge = (
       l1Signer: l1.signer,
       l2Provider: l2.signer.provider,
       erc20L1Address,
-      amount
+      amount,
+      retryableGasOverrides: {
+        maxGas: { percentIncrease: BigNumber.from(50) }
+      }
     })
 
     addTransaction({


### PR DESCRIPTION
L2 NodeInterface under-estimate gas when there is gas refund. Previously in [arb-ts](https://github.com/OffchainLabs/arbitrum/blob/2122496cb932e0453345c12ec0a20b294c2e2841/packages/arb-ts/src/lib/bridge.ts#L343) a 50% buffer is used by default as a workaround. Adding `retryableGasOverrides` here to restore old behavior before NodeInterface is fixed.