### PR TITLE
fix: lift state for current l1 block number

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -13,6 +13,7 @@ import { ConnectionState } from 'src/util/index'
 import { TokenBridgeParams } from 'token-bridge-sdk'
 import { L1Network, L2Network } from '@arbitrum/sdk'
 
+import { AppContext } from './AppContext'
 import { config, useActions, useAppState } from '../../state'
 import { modalProviderOpts } from '../../util/modelProviderOpts'
 import { Alert } from '../common/Alert'
@@ -311,12 +312,12 @@ const Injector = ({ children }: { children: React.ReactNode }): JSX.Element => {
   }, [library, networksAndSigners.isConnectedToArbitrum])
 
   return (
-    <>
+    <AppContext.Provider value={{ currentL1BlockNumber }}>
       {tokenBridgeParams && (
         <ArbTokenBridgeStoreSync tokenBridgeParams={tokenBridgeParams} />
       )}
       {children}
-    </>
+    </AppContext.Provider>
   )
 }
 

--- a/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react'
+
+interface AppContextValue {
+  currentL1BlockNumber: number
+}
+
+export const AppContext = createContext<AppContextValue>({
+  currentL1BlockNumber: 0
+})
+
+export function useAppContext() {
+  return useContext(AppContext)
+}

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -14,8 +14,8 @@ import ExplorerLink from '../common/ExplorerLink'
 import { StatusBadge } from '../common/StatusBadge'
 import { Tooltip } from '../common/Tooltip'
 
+import { useAppContext } from '../App/AppContext'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
-import { useBlockNumber } from '../../hooks/useBlockNumber'
 
 interface TransactionsTableProps {
   transactions: MergedTransaction[]
@@ -91,11 +91,11 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
     app: { arbTokenBridge, isDepositMode }
   } = useAppState()
   const {
-    l1: { network: l1Network, signer: l1Signer },
+    l1: { network: l1Network },
     l2: { network: l2Network, signer: l2Signer },
     isConnectedToArbitrum
   } = useNetworksAndSigners()
-  const currentL1BlockNumber = useBlockNumber(l1Signer?.provider)
+  const { currentL1BlockNumber } = useAppContext()
 
   const [isClaiming, setIsClaiming] = useState(false)
 


### PR DESCRIPTION
Previously, `App.tsx` and `TransactionsTable.tsx` were both using the `useBlockNumber` hook, and had their own record of the current L1 block number. As the default value is `0`, this was causing wrong time estimations until a block is produced and the value in `TransactionsTable.tsx` is updated. 

Creating a context and lifting the state up seemed like the best solution, as we'll certainly need a global context going forward.