### PR TITLE
fix: wrong provider used in getL2GatewayAddress

### DIFF
--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -268,7 +268,7 @@ export const useArbTokenBridge = (
   }
 
   async function getL2GatewayAddress(erc20L1Address: string): Promise<string> {
-    return erc20Bridger.getL2GatewayAddress(erc20L1Address, l1.signer.provider)
+    return erc20Bridger.getL2GatewayAddress(erc20L1Address, l2.signer.provider)
   }
 
   /**


### PR DESCRIPTION
- [x] Fix `Error: Signer/provider chain id: 1 doesn't match provided chain id: 42161.`