### PR TITLE
fix: missing seqNum in pending deposit-l1 txs

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
@@ -33,7 +33,7 @@ export function PendingTransactionsUpdater(): JSX.Element {
         return null
       }
 
-      if (tx.type == 'deposit-l1' && !tx.seqNum) {
+      if (tx.type == 'deposit-l1') {
         // We need to get the seqNum for deposit tx if its missing
         return provider
           .getTransactionReceipt(tx.txID)

--- a/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
@@ -37,13 +37,9 @@ export function PendingTransactionsUpdater(): JSX.Element {
         // We need to get the seqNum for deposit tx if its missing
         return provider
           .getTransactionReceipt(tx.txID)
-          .then(async (txr: TransactionReceiptWithSeqNum) => {
-            const l1ToL2Msg = await new L1TransactionReceipt(
-              txr
-            ).getL1ToL2Message(provider)
-            const seqNum = l1ToL2Msg.messageNumber
-            txr.seqNum = seqNum.toNumber()
-            return txr
+          .then(async (txr: TransactionReceipt) => {
+            const l1ToL2Msg = await new L1TransactionReceipt(txr).getL1ToL2Message(provider)
+            return { ...txr, seqNum: l1ToL2Msg.messageNumber.toNumber()}
           })
       } else {
         return provider.getTransactionReceipt(tx.txID)

--- a/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
+++ b/packages/arb-token-bridge-ui/src/components/syncers/PendingTransactionsUpdater.tsx
@@ -7,6 +7,12 @@ import { useActions, useAppState } from '../../state'
 import { useInterval } from '../common/Hooks'
 import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 
+import { L1TransactionReceipt } from '@arbitrum/sdk'
+
+interface TransactionReceiptWithSeqNum extends TransactionReceipt {
+  seqNum?: number // for l1-initiati
+}
+
 export function PendingTransactionsUpdater(): JSX.Element {
   const actions = useActions()
   const {
@@ -27,7 +33,21 @@ export function PendingTransactionsUpdater(): JSX.Element {
         return null
       }
 
-      return provider.getTransactionReceipt(tx.txID)
+      if (tx.type == 'deposit-l1' && !tx.seqNum) {
+        // We need to get the seqNum for deposit tx if its missing
+        return provider
+          .getTransactionReceipt(tx.txID)
+          .then(async (txr: TransactionReceiptWithSeqNum) => {
+            const l1ToL2Msg = await new L1TransactionReceipt(
+              txr
+            ).getL1ToL2Message(provider)
+            const seqNum = l1ToL2Msg.messageNumber
+            txr.seqNum = seqNum.toNumber()
+            return txr
+          })
+      } else {
+        return provider.getTransactionReceipt(tx.txID)
+      }
     },
     [l1Signer, l2Signer]
   )
@@ -44,17 +64,23 @@ export function PendingTransactionsUpdater(): JSX.Element {
       // eslint-disable-next-line consistent-return
       return Promise.all(
         pendingTransactions.map((tx: Transaction) => getTransactionReceipt(tx))
-      ).then((txReceipts: (TransactionReceipt | null)[]) => {
-        txReceipts.forEach((txReceipt: TransactionReceipt | null, i) => {
-          if (!txReceipt) {
-            console.info(
-              'Transaction receipt not yet found:',
-              pendingTransactions[i].txID
-            )
-          } else {
-            arbTokenBridge?.transactions?.updateTransaction(txReceipt)
+      ).then((txReceipts: (TransactionReceiptWithSeqNum | null)[]) => {
+        txReceipts.forEach(
+          (txReceipt: TransactionReceiptWithSeqNum | null, i) => {
+            if (!txReceipt) {
+              console.info(
+                'Transaction receipt not yet found:',
+                pendingTransactions[i].txID
+              )
+            } else {
+              arbTokenBridge?.transactions?.updateTransaction(
+                txReceipt,
+                undefined,
+                txReceipt.seqNum
+              )
+            }
           }
-        })
+        )
       })
     }
   }, [getTransactionReceipt, arbTokenBridge, arbTokenBridgeLoaded])


### PR DESCRIPTION
If seqNum is missing (e.g. user exited the page before l1 tx confirmed) we need to retrieve it in `checkAndUpdatePendingTransactions` so that the user can re-execute / redeem a failed retryable in https://github.com/OffchainLabs/arb-token-bridge/blob/f0001ab6234966c3b10ed3419a47bcd09e2ec31a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx#L124-L125
Alternatively we can retrieve it within the `redeemRetryable`, not sure which is better because this patch is ugly too.