### PR TITLE
refactor: lift networks and signers state to context

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -32,7 +32,8 @@ import { TermsOfService, TOS_VERSION } from '../TermsOfService/TermsOfService'
 
 import {
   useNetworksAndSigners,
-  UseNetworksAndSignersStatus
+  UseNetworksAndSignersStatus,
+  NetworksAndSignersProvider
 } from '../../hooks/useNetworksAndSigners'
 import { useBlockNumber } from '../../hooks/useBlockNumber'
 
@@ -352,31 +353,31 @@ function Routes() {
   )
 }
 
-function NetworkReady({ children }: { children: JSX.Element }): JSX.Element {
-  const { status } = useNetworksAndSigners()
-
+function ConnectionFallback({
+  status
+}: {
+  status:
+    | UseNetworksAndSignersStatus.NOT_SUPPORTED
+    | UseNetworksAndSignersStatus.NOT_CONNECTED
+}): JSX.Element {
   if (status === UseNetworksAndSignersStatus.NOT_CONNECTED) {
     return <NoMetamaskIndicator />
   }
 
-  if (status === UseNetworksAndSignersStatus.NOT_SUPPORTED) {
-    return (
-      <div>
-        <div className="mb-4">
-          You are on the wrong network. Read our tutorial below on how to switch
-          networks.
-        </div>
-        <iframe
-          title="Bridge Tutorial"
-          src="https://arbitrum.io/bridge-tutorial/"
-          width="100%"
-          height={500}
-        />
+  return (
+    <div>
+      <div className="mb-4">
+        You are on the wrong network. Read our tutorial below on how to switch
+        networks.
       </div>
-    )
-  }
-
-  return children
+      <iframe
+        title="Bridge Tutorial"
+        src="https://arbitrum.io/bridge-tutorial/"
+        width="100%"
+        height={500}
+      />
+    </div>
+  )
 }
 
 const App = (): JSX.Element => {
@@ -384,13 +385,19 @@ const App = (): JSX.Element => {
 
   return (
     <Provider value={overmind}>
-      <Layout>
-        <NetworkReady>
+      <NetworksAndSignersProvider
+        fallback={status => (
+          <Layout>
+            <ConnectionFallback status={status} />
+          </Layout>
+        )}
+      >
+        <Layout>
           <Injector>
             <Routes />
           </Injector>
-        </NetworkReady>
-      </Layout>
+        </Layout>
+      </NetworksAndSignersProvider>
     </Provider>
   )
 }


### PR DESCRIPTION
One problem with the current implementation of the `useNetworksAndSigners` hook is that state isn't reused between hooks, so if we have multiple components that use the hook, the logic inside gets executed multiple times unnecessarily, which also does bunch of unneeded network requests.

This PR lifts the state up in a context without changing the API of the hook, and also sets up stuff for a future refactor where we can get rid of all the unnecessary optionals in the return type.