### PR TITLE
fix: handle pending withdrawals for invalid tokens

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -274,6 +274,7 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
         case 'success':
           return 'green'
         case 'failure':
+        case 'Failure':
           return 'red'
         case 'pending':
           return 'blue'
@@ -347,6 +348,11 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
             </Tooltip>
           </div>
         )}
+
+        {tx.isWithdrawal &&
+          tx.status === 'Failure' &&
+          tx.nodeBlockDeadline === 'EXECUTE_CALL_EXCEPTION' &&
+          'Outbox call exception'}
 
         {tx.isWithdrawal && tx.status === 'Executed' && 'Already claimed'}
 

--- a/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionsTable/TransactionsTable.tsx
@@ -193,6 +193,9 @@ const TableRow = ({ tx }: { tx: MergedTransaction }): JSX.Element => {
     if (nodeBlockDeadline === 'NODE_NOT_CREATED') {
       return l2Network.chainID === 42161 ? '~ 1 week' : '~1 day'
     }
+    if (nodeBlockDeadline === 'EXECUTE_CALL_EXCEPTION') {
+      return 'EXECUTE_CALL_EXCEPTION'
+    }
 
     // Buffer for after a node is confirmable but isn't yet confirmed; we give ~30 minutes, should be usually/always be less in practice
     const confirmationBufferBlocks = 120

--- a/packages/arb-token-bridge-ui/src/state/app/state.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/state.ts
@@ -198,7 +198,10 @@ export const defaultState: AppState = {
 
       return {
         direction: 'outbox',
-        status: outgoungStateToString[tx.outgoingMessageState],
+        status:
+          tx.nodeBlockDeadline === 'EXECUTE_CALL_EXCEPTION'
+            ? 'Failure'
+            : outgoungStateToString[tx.outgoingMessageState],
         createdAt: dayjs(
           new Date(BigNumber.from(tx.timestamp).toNumber() * 1000)
         ).format('HH:mm:ss MM/DD/YYYY'),

--- a/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
+++ b/packages/token-bridge-sdk/src/hooks/arbTokenBridge.types.ts
@@ -31,7 +31,10 @@ export enum AssetType {
   ETH = 'ETH'
 }
 
-export type NodeBlockDeadlineStatus = number | 'NODE_NOT_CREATED'
+export type NodeBlockDeadlineStatus =
+  | number
+  | 'NODE_NOT_CREATED'
+  | 'EXECUTE_CALL_EXCEPTION'
 
 export type L2ToL1EventResult = L2ToL1TransactionEvent
 

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -209,7 +209,7 @@ export const useArbTokenBridge = (
    */
   async function getL1TokenData(
     erc20L1Address: string,
-    throwOnMissingValue = true
+    throwOnInvalidERC20 = true
   ): Promise<L1TokenData> {
     const l1GatewayAddress = await erc20Bridger.getL1GatewayAddress(
       erc20L1Address,
@@ -228,11 +228,11 @@ export const useArbTokenBridge = (
     })
 
     if (typeof tokenData.balance === 'undefined') {
-      if (throwOnMissingValue) throw new Error(`No balance method available`)
+      if (throwOnInvalidERC20) throw new Error(`No balance method available`)
     }
 
     if (typeof tokenData.allowance === 'undefined') {
-      if (throwOnMissingValue) throw new Error(`No allowance method available`)
+      if (throwOnInvalidERC20) throw new Error(`No allowance method available`)
     }
 
     return {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -207,7 +207,10 @@ export const useArbTokenBridge = (
    * @param erc20L1Address
    * @returns
    */
-  async function getL1TokenData(erc20L1Address: string): Promise<L1TokenData> {
+  async function getL1TokenData(
+    erc20L1Address: string,
+    throwOnMissingValue = false
+  ): Promise<L1TokenData> {
     const l1GatewayAddress = await erc20Bridger.getL1GatewayAddress(
       erc20L1Address,
       l1.signer.provider
@@ -225,18 +228,18 @@ export const useArbTokenBridge = (
     })
 
     if (typeof tokenData.balance === 'undefined') {
-      throw new Error(`No balance method available`)
+      if (throwOnMissingValue) throw new Error(`No balance method available`)
     }
 
     if (typeof tokenData.allowance === 'undefined') {
-      throw new Error(`No allowance method available`)
+      if (throwOnMissingValue) throw new Error(`No allowance method available`)
     }
 
     return {
       name: tokenData.name || getDefaultTokenName(erc20L1Address),
       symbol: tokenData.symbol || getDefaultTokenSymbol(erc20L1Address),
-      balance: tokenData.balance,
-      allowance: tokenData.allowance,
+      balance: tokenData.balance || BigNumber.from(0),
+      allowance: tokenData.allowance || BigNumber.from(0),
       decimals: tokenData.decimals || 0,
       contract
     }
@@ -954,7 +957,7 @@ export const useArbTokenBridge = (
     }
 
     try {
-      const { symbol } = await getL1TokenData(l1Address)
+      const { symbol } = await getL1TokenData(l1Address, false)
       addressToSymbol[l1Address] = symbol
       return symbol
     } catch (err) {
@@ -971,7 +974,7 @@ export const useArbTokenBridge = (
     }
 
     try {
-      const { decimals } = await getL1TokenData(l1Address)
+      const { decimals } = await getL1TokenData(l1Address, false)
       addressToDecimals[l1Address] = decimals
       return decimals
     } catch (err) {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -209,7 +209,7 @@ export const useArbTokenBridge = (
    */
   async function getL1TokenData(
     erc20L1Address: string,
-    throwOnMissingValue = false
+    throwOnMissingValue = true
   ): Promise<L1TokenData> {
     const l1GatewayAddress = await erc20Bridger.getL1GatewayAddress(
       erc20L1Address,

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -1202,11 +1202,21 @@ export const useArbTokenBridge = (
       return { ...event, nodeBlockDeadline: firstExecutableBlock?.toNumber() }
     } catch (e) {
       const expectedError = "batch doesn't exist"
+      const expectedError2 = 'CALL_EXCEPTION'
       const err = e as Error & { error: Error }
       const actualError =
         err && (err.message || (err.error && err.error.message))
       if (actualError.includes(expectedError)) {
         const nodeBlockDeadline: NodeBlockDeadlineStatus = 'NODE_NOT_CREATED'
+        return {
+          ...event,
+          nodeBlockDeadline
+        }
+      } else if (actualError.includes(expectedError2)) {
+        // in classic we simulate `executeTransaction` in `hasExecuted`
+        // which might revert if the L2 to L1 call fail
+        const nodeBlockDeadline: NodeBlockDeadlineStatus =
+          'EXECUTE_CALL_EXCEPTION'
         return {
           ...event,
           nodeBlockDeadline


### PR DESCRIPTION
If a user ever withdrew a token that is broken on L1 (e.g. balance, allowance, or transfer revert), the pending withdrawal list will fail to render at all. One example is the now disabled [DEFI5 token](https://etherscan.io/address/0xfa6de2697D59E88Ed7Fc4dFE5A33daC43565ea41#readProxyContract) which broke the UI for address 0x68a9857b0e540e5a800151d3e4a33037191a5dc4. This PR suppress error in the `setInitialPendingWithdrawals` code path. 