### PR TITLE
feat: make the withdraw only token list work for multiple L2s

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -9,6 +9,7 @@ import { useLatest } from 'react-use'
 
 import { useAppState } from '../../state'
 import { ConnectionState, PendingWithdrawalsLoadedState } from '../../util'
+import { isWithdrawOnlyToken } from '../../util/WithdrawOnlyUtils'
 import { Button } from '../common/Button'
 import { NetworkSwitchButton } from '../common/NetworkSwitchButton'
 import { StatusBadge } from '../common/StatusBadge'
@@ -17,7 +18,6 @@ import TransactionConfirmationModal, {
 } from '../TransactionConfirmationModal/TransactionConfirmationModal'
 import { TokenImportModal } from '../TokenModal/TokenImportModal'
 import { NetworkBox } from './NetworkBox'
-import useWithdrawOnly from './useWithdrawOnly'
 import {
   useNetworksAndSigners,
   UseNetworksAndSignersStatus
@@ -109,7 +109,6 @@ const TransferPanel = (): JSX.Element => {
   const [l1Amount, setL1AmountState] = useState<string>('')
   const [l2Amount, setL2AmountState] = useState<string>('')
 
-  const { shouldDisableDeposit } = useWithdrawOnly()
   const { shouldRequireApprove } = useL2Approve()
 
   useEffect(() => {
@@ -339,8 +338,16 @@ const TransferPanel = (): JSX.Element => {
 
   const disableDeposit = useMemo(() => {
     const l1AmountNum = +l1Amount
+
+    if (
+      isDepositMode &&
+      selectedToken &&
+      isWithdrawOnlyToken(selectedToken.address)
+    ) {
+      return true
+    }
+
     return (
-      shouldDisableDeposit ||
       transferring ||
       l1Amount.trim() === '' ||
       (isDepositMode &&


### PR DESCRIPTION
Simplifies the flow and removes the need to check for the users' L2 balance. We now only check the L1 address to know if we should disable deposits.