### PR TITLE
feat: add indicator for number of pending withdrawals

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -49,6 +49,7 @@ import {
 } from '../../hooks/useNetworksAndSigners'
 import {
   HeaderContent,
+  HeaderMobileNotification,
   HeaderOverrides,
   HeaderOverridesProps
 } from '../common/Header'
@@ -57,6 +58,7 @@ import { HeaderNetworkInformation } from '../common/HeaderNetworkInformation'
 import { HeaderAccountPopover } from '../common/HeaderAccountPopover'
 import { HeaderConnectWalletButton } from '../common/HeaderConnectWalletButton'
 import { Notifications } from '../common/Notifications'
+import { PendingWithdrawalsIndicator } from '../common/PendingWithdrawalsIndicator'
 import { isNetwork } from '../../util/networks'
 
 type Web3Provider = ExternalProvider & {
@@ -133,6 +135,13 @@ const AppContent = (): JSX.Element => {
         <HeaderNetworkInformation />
         <HeaderAccountPopover />
       </HeaderContent>
+
+      <HeaderMobileNotification>
+        <PendingWithdrawalsIndicator
+          loaderProps={{ height: 12, width: 12 }}
+          className="h-4 w-4 border text-[10px]"
+        />
+      </HeaderMobileNotification>
 
       <PendingTransactionsUpdater />
       <RetryableTxnsIncluder />

--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -74,6 +74,8 @@ async function addressIsEOA(_address: string, _signer: JsonRpcSigner) {
 
 const AppContent = (): JSX.Element => {
   const { l1 } = useNetworksAndSigners()
+  const { layout } = useAppContextState()
+  const { isPendingWithdrawalsIndicatorVisible } = layout
   const {
     app: { connectionState }
   } = useAppState()
@@ -137,10 +139,12 @@ const AppContent = (): JSX.Element => {
       </HeaderContent>
 
       <HeaderMobileNotification>
-        <PendingWithdrawalsIndicator
-          loaderProps={{ height: 12, width: 12 }}
-          className="h-4 w-4 border text-[10px]"
-        />
+        {isPendingWithdrawalsIndicatorVisible && (
+          <PendingWithdrawalsIndicator
+            loaderProps={{ height: 12, width: 12 }}
+            className="h-4 w-4 border text-[10px]"
+          />
+        )}
       </HeaderMobileNotification>
 
       <PendingTransactionsUpdater />

--- a/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
@@ -15,6 +15,7 @@ type AppContextState = {
   seenTransactions: string[]
   layout: {
     isTransferPanelVisible: boolean
+    isPendingWithdrawalsIndicatorVisible: boolean
   }
 }
 
@@ -22,7 +23,8 @@ const initialState: AppContextState = {
   currentL1BlockNumber: 0,
   seenTransactions: SeenTransactionsCache.get(),
   layout: {
-    isTransferPanelVisible: true
+    isTransferPanelVisible: true,
+    isPendingWithdrawalsIndicatorVisible: true
   }
 }
 
@@ -34,6 +36,7 @@ type Action =
   | { type: 'set_current_l1_block_number'; payload: number }
   | { type: 'set_tx_as_seen'; payload: string }
   | { type: 'layout.set_is_transfer_panel_visible'; payload: boolean }
+  | { type: 'layout.hide_pending_withdrawals_indicator' }
 
 function reducer(state: AppContextState, action: Action) {
   switch (action.type) {
@@ -55,6 +58,12 @@ function reducer(state: AppContextState, action: Action) {
       return {
         ...state,
         layout: { ...state.layout, isTransferPanelVisible: action.payload }
+      }
+
+    case 'layout.hide_pending_withdrawals_indicator':
+      return {
+        ...state,
+        layout: { ...state.layout, isPendingWithdrawalsIndicatorVisible: false }
       }
 
     default:

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -11,8 +11,6 @@ import { DepositCard } from '../TransferPanel/DepositCard'
 import { WithdrawalCard } from '../TransferPanel/WithdrawalCard'
 import { TransferPanel } from '../TransferPanel/TransferPanel'
 import { ExploreArbitrum } from './ExploreArbitrum'
-import { HeaderMobileNotification } from '../common/Header'
-import { PendingWithdrawalsIndicator } from '../common/PendingWithdrawalsIndicator'
 
 const motionDivProps = {
   layout: true,
@@ -144,13 +142,6 @@ export function MainContent() {
   return (
     <div className="flex w-full justify-center">
       <div className="w-full max-w-screen-lg flex-col space-y-6">
-        <HeaderMobileNotification>
-          <PendingWithdrawalsIndicator
-            loaderProps={{ height: 12, width: 12 }}
-            className="h-4 w-4 border text-[10px]"
-          />
-        </HeaderMobileNotification>
-
         <AnimatePresence>
           {didLoadPendingWithdrawals && (
             <>

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -75,7 +75,6 @@ export function MainContent() {
   const { seenTransactions, layout } = useAppContextState()
   const { isTransferPanelVisible } = layout
   const dispatch = useAppContextDispatch()
-
   const unseenTransactionsWithDuplicates = mergedTransactions
     // Exclude seen txs
     .filter(tx => !seenTransactions.includes(tx.txId))

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -12,6 +12,7 @@ import { DepositCard } from '../TransferPanel/DepositCard'
 import { WithdrawalCard } from '../TransferPanel/WithdrawalCard'
 import { TransferPanel } from '../TransferPanel/TransferPanel'
 import { ExploreArbitrum } from './ExploreArbitrum'
+import { HeaderMobileNotification } from '../common/Header'
 import { HeaderAccountPopoverNotification } from '../common/HeaderAccountPopover'
 
 const motionDivProps = {
@@ -175,6 +176,10 @@ export function MainContent() {
         <HeaderAccountPopoverNotification>
           <PendingWithdrawalsIndicator />
         </HeaderAccountPopoverNotification>
+
+        <HeaderMobileNotification>
+          <PendingWithdrawalsIndicator />
+        </HeaderMobileNotification>
 
         <AnimatePresence>
           {didLoadPendingWithdrawals && (

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -70,22 +70,30 @@ function dedupeWithdrawals(transactions: MergedTransaction[]) {
   return Object.values(map)
 }
 
-function WithdrawalsIndicator({ amount }: { amount: number }) {
+function PendingWithdrawalsIndicator() {
   const { app } = useAppState()
-  const { pwLoadedState } = app
+  const { pwLoadedState, withdrawalsTransformed } = app
+
+  const amount = useMemo(
+    () =>
+      withdrawalsTransformed.filter(
+        tx => tx.status === 'Unconfirmed' || tx.status === 'Confirmed'
+      ).length,
+    [withdrawalsTransformed]
+  )
 
   if (pwLoadedState === PendingWithdrawalsLoadedState.READY && amount === 0) {
     return null
   }
 
   return (
-    <div className="border-1 flex h-4 w-4 items-center justify-center rounded-full border-white bg-brick text-xs transition-colors duration-500 lg:h-6 lg:w-6 lg:border-2">
+    <div className="flex h-4 w-4 items-center justify-center rounded-full border border-white bg-brick transition-colors duration-500 lg:h-6 lg:w-6 lg:border-2">
       {pwLoadedState === PendingWithdrawalsLoadedState.LOADING && (
         <Loader type="TailSpin" color="black" height={14} width={14} />
       )}
 
       {pwLoadedState === PendingWithdrawalsLoadedState.READY && (
-        <span className="text-xs">{amount}</span>
+        <span className="text-[10px] lg:text-xs">{amount}</span>
       )}
     </div>
   )
@@ -118,11 +126,6 @@ export function MainContent() {
   const didLoadPendingWithdrawals = useMemo(
     () => pwLoadedState === PendingWithdrawalsLoadedState.READY,
     [pwLoadedState]
-  )
-
-  const numberOfPendingWithdrawals = useMemo(
-    () => unseenTransactions.filter(tx => !isDeposit(tx)).length,
-    [unseenTransactions]
   )
 
   useEffect(() => {
@@ -170,7 +173,7 @@ export function MainContent() {
     <div className="flex w-full justify-center">
       <div className="w-full max-w-screen-lg flex-col space-y-6">
         <HeaderAccountPopoverNotification>
-          <WithdrawalsIndicator amount={numberOfPendingWithdrawals} />
+          <PendingWithdrawalsIndicator />
         </HeaderAccountPopoverNotification>
 
         <AnimatePresence>

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import { useMedia, usePrevious } from 'react-use'
 import { motion, AnimatePresence } from 'framer-motion'
-import { twMerge } from 'tailwind-merge'
-import Loader from 'react-loader-spinner'
 
 import { PendingWithdrawalsLoadedState } from '../../util'
 import { useAppState } from '../../state'
@@ -15,6 +13,7 @@ import { TransferPanel } from '../TransferPanel/TransferPanel'
 import { ExploreArbitrum } from './ExploreArbitrum'
 import { HeaderMobileNotification } from '../common/Header'
 import { HeaderAccountPopoverNotification } from '../common/HeaderAccountPopover'
+import { PendingWithdrawalsIndicator } from '../common/PendingWithdrawalsIndicator'
 
 const motionDivProps = {
   layout: true,
@@ -70,54 +69,6 @@ function dedupeWithdrawals(transactions: MergedTransaction[]) {
   })
 
   return Object.values(map)
-}
-
-type PendingWithdrawalsIndicatorProps = {
-  loaderProps?: { width: number; height: number }
-  className?: string
-}
-
-function PendingWithdrawalsIndicator({
-  loaderProps = { width: 14, height: 14 },
-  className = ''
-}: PendingWithdrawalsIndicatorProps) {
-  const { app } = useAppState()
-  const { pwLoadedState, withdrawalsTransformed } = app
-
-  const amount = useMemo(
-    () =>
-      withdrawalsTransformed.filter(
-        tx => tx.status === 'Unconfirmed' || tx.status === 'Confirmed'
-      ).length,
-    [withdrawalsTransformed]
-  )
-
-  if (pwLoadedState === PendingWithdrawalsLoadedState.READY && amount === 0) {
-    return null
-  }
-
-  const bgClassName =
-    pwLoadedState === PendingWithdrawalsLoadedState.LOADING
-      ? 'bg-white'
-      : 'bg-brick'
-
-  return (
-    <div
-      className={twMerge(
-        'flex items-center justify-center rounded-full border-white transition-colors',
-        bgClassName,
-        className
-      )}
-    >
-      {pwLoadedState === PendingWithdrawalsLoadedState.LOADING && (
-        <Loader type="TailSpin" color="black" {...loaderProps} />
-      )}
-
-      {pwLoadedState === PendingWithdrawalsLoadedState.READY && (
-        <span>{amount}</span>
-      )}
-    </div>
-  )
 }
 
 export function MainContent() {

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { useMedia, usePrevious } from 'react-use'
+import { usePrevious } from 'react-use'
 import { motion, AnimatePresence } from 'framer-motion'
 
 import { PendingWithdrawalsLoadedState } from '../../util'
@@ -12,7 +12,6 @@ import { WithdrawalCard } from '../TransferPanel/WithdrawalCard'
 import { TransferPanel } from '../TransferPanel/TransferPanel'
 import { ExploreArbitrum } from './ExploreArbitrum'
 import { HeaderMobileNotification } from '../common/Header'
-import { HeaderAccountPopoverNotification } from '../common/HeaderAccountPopover'
 import { PendingWithdrawalsIndicator } from '../common/PendingWithdrawalsIndicator'
 
 const motionDivProps = {
@@ -78,7 +77,6 @@ export function MainContent() {
   const { seenTransactions, layout } = useAppContextState()
   const { isTransferPanelVisible } = layout
   const dispatch = useAppContextDispatch()
-  const isLarge = useMedia('(min-width: 1024px)')
 
   const unseenTransactionsWithDuplicates = mergedTransactions
     // Exclude seen txs
@@ -101,8 +99,6 @@ export function MainContent() {
     () => pwLoadedState === PendingWithdrawalsLoadedState.READY,
     [pwLoadedState]
   )
-
-  const loaderSize = isLarge ? 14 : 24
 
   useEffect(() => {
     const prevUnseenTransactionsLength = prevUnseenTransactions?.length || 0
@@ -148,13 +144,6 @@ export function MainContent() {
   return (
     <div className="flex w-full justify-center">
       <div className="w-full max-w-screen-lg flex-col space-y-6">
-        <HeaderAccountPopoverNotification>
-          <PendingWithdrawalsIndicator
-            loaderProps={{ height: loaderSize, width: loaderSize }}
-            className="h-11 w-11 border-2 text-sm lg:h-6 lg:w-6 lg:text-xs"
-          />
-        </HeaderAccountPopoverNotification>
-
         <HeaderMobileNotification>
           <PendingWithdrawalsIndicator
             loaderProps={{ height: 12, width: 12 }}

--- a/packages/arb-token-bridge-ui/src/components/common/Header.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Header.tsx
@@ -2,6 +2,7 @@ import React, { ImgHTMLAttributes, useEffect, useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { Disclosure } from '@headlessui/react'
 import { twMerge } from 'tailwind-merge'
+import { useMedia } from 'react-use'
 
 import { Transition } from './Transition'
 import { ExternalLink } from './ExternalLink'
@@ -90,7 +91,7 @@ const MenuIcon = {
   }
 }
 
-function useResponsiveHeaderPortal() {
+export function useResponsiveHeaderPortal() {
   const mutationObserverRef = useRef<MutationObserver>()
   const [, setMutationCycleCount] = useState(0)
 
@@ -175,8 +176,10 @@ function HeaderImageElement({ ...props }: ImgHTMLAttributes<HTMLImageElement>) {
 
 export function HeaderContent({ children }: { children: React.ReactNode }) {
   useResponsiveHeaderPortal()
+  const isLarge = useMedia('(min-width: 1024px)')
 
-  const rootElement = document.getElementById('header-content-root')
+  const size = isLarge ? 'desktop' : 'mobile'
+  const rootElement = document.getElementById(`header-content-root-${size}`)
 
   if (!rootElement) {
     return null
@@ -286,7 +289,7 @@ export function Header() {
         </Disclosure>
         <div className="hidden flex-grow items-center justify-end lg:flex lg:space-x-2 xl:space-x-4">
           <div
-            id="header-content-root"
+            id="header-content-root-desktop"
             className="flex space-x-2 xl:space-x-4"
           ></div>
           <div className="flex flex-row space-x-2 xl:space-x-4">
@@ -333,7 +336,7 @@ function HeaderMobile() {
       </div>
       <div className="flex min-h-screen flex-col items-center space-y-3 bg-blue-arbitrum pt-4">
         <div
-          id="header-content-root"
+          id="header-content-root-mobile"
           className="flex w-full flex-col items-center space-y-3"
         ></div>
         <HeaderMenuMobile

--- a/packages/arb-token-bridge-ui/src/components/common/Header.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Header.tsx
@@ -195,7 +195,7 @@ export function HeaderMobileNotification({
 }) {
   useResponsiveHeaderPortal()
 
-  const rootElement = document.getElementById('header-mobile-notification-root')
+  const rootElement = document.getElementById('header-notification-root-mobile')
 
   if (!rootElement) {
     return null
@@ -274,7 +274,7 @@ export function Header() {
                 <Disclosure.Button className="relative lg:hidden">
                   <MenuIcon.Open />
                   <div
-                    id="header-mobile-notification-root"
+                    id="header-notification-root-mobile"
                     className="absolute -top-3 -right-2"
                   ></div>
                 </Disclosure.Button>

--- a/packages/arb-token-bridge-ui/src/components/common/Header.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Header.tsx
@@ -185,6 +185,22 @@ export function HeaderContent({ children }: { children: React.ReactNode }) {
   return ReactDOM.createPortal(children, rootElement)
 }
 
+export function HeaderMobileNotification({
+  children
+}: {
+  children: React.ReactNode
+}) {
+  useResponsiveHeaderPortal()
+
+  const rootElement = document.getElementById('header-mobile-notification-root')
+
+  if (!rootElement) {
+    return null
+  }
+
+  return ReactDOM.createPortal(children, rootElement)
+}
+
 export function Header() {
   return (
     <header id="header" className={defaultHeaderClassName}>
@@ -252,8 +268,12 @@ export function Header() {
           {({ open }) => (
             <div className="flex items-center">
               {!open && (
-                <Disclosure.Button className="lg:hidden">
+                <Disclosure.Button className="relative lg:hidden">
                   <MenuIcon.Open />
+                  <div
+                    id="header-mobile-notification-root"
+                    className="absolute -top-3 -right-2"
+                  ></div>
                 </Disclosure.Button>
               )}
               <Disclosure.Panel>

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -21,7 +21,10 @@ import {
 } from '../TransactionsTable/TransactionsTable'
 import { SafeImage } from './SafeImage'
 import { ReactComponent as CustomClipboardCopyIcon } from '../../assets/copy.svg'
-import { PendingWithdrawalsIndicator } from './PendingWithdrawalsIndicator'
+import {
+  PendingWithdrawalsIndicator,
+  usePendingWithdrawalsIndicator
+} from './PendingWithdrawalsIndicator'
 
 type ENSInfo = { name: string | null; avatar: string | null }
 const ensInfoDefaults: ENSInfo = { name: null, avatar: null }
@@ -78,6 +81,11 @@ async function tryGetAvatar(
   }
 }
 
+function PopoverPanelEventListener({ onOpen }: { onOpen: () => void }) {
+  useEffect(() => onOpen(), [onOpen])
+  return null
+}
+
 export function HeaderAccountPopover() {
   const { disconnect, account, web3Modal } = useWallet()
   const { status, l1, l2, isConnectedToArbitrum } = useNetworksAndSigners()
@@ -85,6 +93,10 @@ export function HeaderAccountPopover() {
   const {
     app: { mergedTransactions, pwLoadedState }
   } = useAppState()
+  const {
+    isVisible: isPendingWithdrawalsIndicatorVisible,
+    hide: hidePendingWithdrawalsIndicator
+  } = usePendingWithdrawalsIndicator()
   const isLarge = useMedia('(min-width: 1024px)')
 
   const [showCopied, setShowCopied] = useState(false)
@@ -167,15 +179,19 @@ export function HeaderAccountPopover() {
             </span>
           </div>
         </div>
-        <div className="absolute right-6 flex justify-center lg:-bottom-2 lg:-right-2">
-          <PendingWithdrawalsIndicator
-            loaderProps={{ height: loaderSize, width: loaderSize }}
-            className="h-11 w-11 border-2 text-sm lg:h-6 lg:w-6 lg:text-xs"
-          />
-        </div>
+
+        {isPendingWithdrawalsIndicatorVisible && (
+          <div className="absolute right-6 flex justify-center lg:-bottom-2 lg:-right-2">
+            <PendingWithdrawalsIndicator
+              loaderProps={{ height: loaderSize, width: loaderSize }}
+              className="h-11 w-11 border-2 text-sm lg:h-6 lg:w-6 lg:text-xs"
+            />
+          </div>
+        )}
       </Popover.Button>
       <Transition>
         <Popover.Panel className="relative right-0 flex h-96 flex-col rounded-md lg:absolute lg:mt-4 lg:min-w-[896px] lg:shadow-[0px_4px_20px_rgba(0,0,0,0.2)]">
+          <PopoverPanelEventListener onOpen={hidePendingWithdrawalsIndicator} />
           <div className="bg-blue-arbitrum p-4 lg:rounded-tl-md lg:rounded-tr-md">
             <div className="flex flex-row justify-between">
               <Transition show={showCopied}>

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useEffect, useMemo, useState } from 'react'
-import ReactDOM from 'react-dom'
-import { useCopyToClipboard } from 'react-use'
+import { useCopyToClipboard, useMedia } from 'react-use'
 import { useWallet } from '@arbitrum/use-wallet'
 import { Popover, Tab } from '@headlessui/react'
 import { ExternalLinkIcon, LogoutIcon } from '@heroicons/react/outline'
@@ -21,8 +20,8 @@ import {
   TransactionsDataStatus
 } from '../TransactionsTable/TransactionsTable'
 import { SafeImage } from './SafeImage'
-import { useResponsiveHeaderPortal } from './Header'
 import { ReactComponent as CustomClipboardCopyIcon } from '../../assets/copy.svg'
+import { PendingWithdrawalsIndicator } from './PendingWithdrawalsIndicator'
 
 type ENSInfo = { name: string | null; avatar: string | null }
 const ensInfoDefaults: ENSInfo = { name: null, avatar: null }
@@ -79,24 +78,6 @@ async function tryGetAvatar(
   }
 }
 
-export function HeaderAccountPopoverNotification({
-  children
-}: {
-  children: React.ReactNode
-}) {
-  useResponsiveHeaderPortal()
-
-  const rootElement = document.getElementById(
-    'header-account-popover-notification-root'
-  )
-
-  if (!rootElement) {
-    return null
-  }
-
-  return ReactDOM.createPortal(children, rootElement)
-}
-
 export function HeaderAccountPopover() {
   const { disconnect, account, web3Modal } = useWallet()
   const { status, l1, l2, isConnectedToArbitrum } = useNetworksAndSigners()
@@ -104,9 +85,12 @@ export function HeaderAccountPopover() {
   const {
     app: { mergedTransactions, pwLoadedState }
   } = useAppState()
+  const isLarge = useMedia('(min-width: 1024px)')
 
   const [showCopied, setShowCopied] = useState(false)
   const [ensInfo, setENSInfo] = useState<ENSInfo>(ensInfoDefaults)
+
+  const loaderSize = isLarge ? 14 : 24
 
   useEffect(() => {
     async function resolveENSInfo() {
@@ -183,10 +167,12 @@ export function HeaderAccountPopover() {
             </span>
           </div>
         </div>
-        <div
-          id="header-account-popover-notification-root"
-          className="absolute right-6 flex justify-center lg:-bottom-2 lg:-right-2"
-        ></div>
+        <div className="absolute right-6 flex justify-center lg:-bottom-2 lg:-right-2">
+          <PendingWithdrawalsIndicator
+            loaderProps={{ height: loaderSize, width: loaderSize }}
+            className="h-11 w-11 border-2 text-sm lg:h-6 lg:w-6 lg:text-xs"
+          />
+        </div>
       </Popover.Button>
       <Transition>
         <Popover.Panel className="relative right-0 flex h-96 flex-col rounded-md lg:absolute lg:mt-4 lg:min-w-[896px] lg:shadow-[0px_4px_20px_rgba(0,0,0,0.2)]">

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useEffect, useMemo, useState } from 'react'
+import ReactDOM from 'react-dom'
 import { useCopyToClipboard } from 'react-use'
 import { useWallet } from '@arbitrum/use-wallet'
 import { Popover, Tab } from '@headlessui/react'
@@ -75,6 +76,22 @@ async function tryGetAvatar(
   } catch (error) {
     return null
   }
+}
+
+export function HeaderAccountPopoverNotification({
+  children
+}: {
+  children: React.ReactNode
+}) {
+  const rootElement = document.getElementById(
+    'header-account-popover-notification-root'
+  )
+
+  if (!rootElement) {
+    return null
+  }
+
+  return ReactDOM.createPortal(children, rootElement)
 }
 
 export function HeaderAccountPopover() {
@@ -163,6 +180,10 @@ export function HeaderAccountPopover() {
             </span>
           </div>
         </div>
+        <div
+          id="header-account-popover-notification-root"
+          className="absolute -bottom-2 -right-2 hidden lg:flex"
+        ></div>
       </Popover.Button>
       <Transition>
         <Popover.Panel className="relative right-0 flex h-96 flex-col rounded-md lg:absolute lg:mt-4 lg:min-w-[896px] lg:shadow-[0px_4px_20px_rgba(0,0,0,0.2)]">

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -170,7 +170,7 @@ export function HeaderAccountPopover() {
 
   return (
     <Popover className="relative z-50 w-full lg:w-max">
-      <Popover.Button className="arb-hover flex w-full justify-center rounded-full lg:w-max">
+      <Popover.Button className="arb-hover flex w-full items-center justify-center rounded-full lg:w-max">
         <div className="py-3 lg:py-0">
           <div className="flex flex-row items-center space-x-3 rounded-full lg:bg-dark lg:px-4 lg:py-2">
             <SafeImage
@@ -185,7 +185,7 @@ export function HeaderAccountPopover() {
         </div>
         <div
           id="header-account-popover-notification-root"
-          className="absolute -bottom-2 -right-2 hidden lg:flex"
+          className="absolute right-6 flex justify-center lg:-bottom-2 lg:-right-2"
         ></div>
       </Popover.Button>
       <Transition>

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -21,6 +21,7 @@ import {
   TransactionsDataStatus
 } from '../TransactionsTable/TransactionsTable'
 import { SafeImage } from './SafeImage'
+import { useResponsiveHeaderPortal } from './Header'
 import { ReactComponent as CustomClipboardCopyIcon } from '../../assets/copy.svg'
 
 type ENSInfo = { name: string | null; avatar: string | null }
@@ -83,6 +84,8 @@ export function HeaderAccountPopoverNotification({
 }: {
   children: React.ReactNode
 }) {
+  useResponsiveHeaderPortal()
+
   const rootElement = document.getElementById(
     'header-account-popover-notification-root'
   )

--- a/packages/arb-token-bridge-ui/src/components/common/PendingWithdrawalsIndicator.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/PendingWithdrawalsIndicator.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react'
+import { twMerge } from 'tailwind-merge'
+import Loader from 'react-loader-spinner'
+
+import { useAppState } from '../../state'
+import { PendingWithdrawalsLoadedState } from '../../util'
+
+export type PendingWithdrawalsIndicatorProps = {
+  loaderProps?: { width: number; height: number }
+  className?: string
+}
+
+export function PendingWithdrawalsIndicator({
+  loaderProps = { width: 14, height: 14 },
+  className = ''
+}: PendingWithdrawalsIndicatorProps) {
+  const { app } = useAppState()
+  const { pwLoadedState, withdrawalsTransformed } = app
+
+  const amount = useMemo(
+    () =>
+      withdrawalsTransformed.filter(
+        tx => tx.status === 'Unconfirmed' || tx.status === 'Confirmed'
+      ).length,
+    [withdrawalsTransformed]
+  )
+
+  if (pwLoadedState === PendingWithdrawalsLoadedState.READY && amount === 0) {
+    return null
+  }
+
+  const bgClassName =
+    pwLoadedState === PendingWithdrawalsLoadedState.LOADING
+      ? 'bg-white'
+      : 'bg-brick'
+
+  return (
+    <div
+      className={twMerge(
+        'flex items-center justify-center rounded-full border-white transition-colors',
+        bgClassName,
+        className
+      )}
+    >
+      {pwLoadedState === PendingWithdrawalsLoadedState.LOADING && (
+        <Loader type="TailSpin" color="black" {...loaderProps} />
+      )}
+
+      {pwLoadedState === PendingWithdrawalsLoadedState.READY && (
+        <span>{amount}</span>
+      )}
+    </div>
+  )
+}

--- a/packages/arb-token-bridge-ui/src/components/common/PendingWithdrawalsIndicator.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/PendingWithdrawalsIndicator.tsx
@@ -1,9 +1,29 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 import Loader from 'react-loader-spinner'
 
 import { useAppState } from '../../state'
 import { PendingWithdrawalsLoadedState } from '../../util'
+import { useAppContextDispatch, useAppContextState } from '../App/AppContext'
+
+export function usePendingWithdrawalsIndicator() {
+  const { app } = useAppState()
+  const { pwLoadedState } = app
+
+  const { layout } = useAppContextState()
+  const { isPendingWithdrawalsIndicatorVisible } = layout
+
+  const dispatch = useAppContextDispatch()
+
+  const hide = useCallback(() => {
+    // Don't hide indicator while loading
+    if (pwLoadedState !== PendingWithdrawalsLoadedState.LOADING) {
+      dispatch({ type: 'layout.hide_pending_withdrawals_indicator' })
+    }
+  }, [dispatch, pwLoadedState])
+
+  return { isVisible: isPendingWithdrawalsIndicatorVisible, hide }
+}
 
 export type PendingWithdrawalsIndicatorProps = {
   loaderProps?: { width: number; height: number }

--- a/packages/arb-token-bridge-ui/src/styles/tailwind.css
+++ b/packages/arb-token-bridge-ui/src/styles/tailwind.css
@@ -162,6 +162,10 @@ input:checked + .slider:before {
   color: #595959;
 }
 
+.text-\[10px\] {
+  font-size: 0.625rem; /* 10px */
+}
+
 /* border */
 .border-\[\#cd0000\] {
   border-color: #cd0000;


### PR DESCRIPTION
Adds a new `PendingWithdrawalsIndicator` component, along with a companion hook `usePendingWithdrawalsIndicator` for tracking and manipulating its state across the app. 

The component is rendered in the header and will display the number of pending withdrawals, prompting the user to open the popover with their transaction history. The indicator is hidden once the user opens the popover.

Demo video:

https://user-images.githubusercontent.com/20543771/181222160-c4ba344b-cbfe-40c6-a75a-c41f0808e744.mov