### PR TITLE
fix: handle mid-transfer network switch 

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arb-token-bridge-ui",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "dependencies": {
     "@ethersproject/providers": "^5.4.4",

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -146,20 +146,16 @@ export function MainContent() {
     <div className="flex w-full justify-center">
       <div className="w-full max-w-screen-lg flex-col space-y-6">
         <AnimatePresence>
-          {didLoadPendingWithdrawals && (
-            <>
-              {unseenTransactions.map(tx =>
-                isDeposit(tx) ? (
-                  <motion.div key={tx.txId} {...motionDivProps}>
-                    <DepositCard key={tx.txId} tx={tx} />
-                  </motion.div>
-                ) : (
-                  <motion.div key={tx.txId} {...motionDivProps}>
-                    <WithdrawalCard key={tx.txId} tx={tx} />
-                  </motion.div>
-                )
-              )}
-            </>
+          {unseenTransactions.map(tx =>
+            isDeposit(tx) ? (
+              <motion.div key={tx.txId} {...motionDivProps}>
+                <DepositCard key={tx.txId} tx={tx} />
+              </motion.div>
+            ) : (
+              <motion.div key={tx.txId} {...motionDivProps}>
+                <WithdrawalCard key={tx.txId} tx={tx} />
+              </motion.div>
+            )
           )}
         </AnimatePresence>
 
@@ -176,7 +172,7 @@ export function MainContent() {
         </AnimatePresence>
 
         <AnimatePresence>
-          {didLoadPendingWithdrawals && unseenTransactions.length > 0 && (
+          {unseenTransactions.length > 0 && (
             <>
               <motion.div key="explore-arbitrum" {...motionDivProps}>
                 <ExploreArbitrum />

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -163,7 +163,7 @@ export function MainContent() {
           )}
         </AnimatePresence>
 
-        <AnimatePresence exitBeforeEnter>
+        <AnimatePresence>
           {isTransferPanelVisible && (
             <motion.div
               key="transfer-panel"
@@ -173,7 +173,9 @@ export function MainContent() {
               <TransferPanel />
             </motion.div>
           )}
+        </AnimatePresence>
 
+        <AnimatePresence>
           {didLoadPendingWithdrawals && unseenTransactions.length > 0 && (
             <>
               <motion.div key="explore-arbitrum" {...motionDivProps}>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -411,6 +411,13 @@ export function TransferPanel() {
           })
         }
       } else {
+        const waitForInput = openWithdrawalConfirmationDialog()
+        const confirmed = await waitForInput()
+
+        if (!confirmed) {
+          return
+        }
+
         if (!latestNetworksAndSigners.current.isConnectedToArbitrum) {
           trackEvent('Switch Network and Transfer')
           await changeNetwork?.(latestNetworksAndSigners.current.l2.network)
@@ -433,13 +440,6 @@ export function TransferPanel() {
           !(l2ChainID && connectedChainID && +l2ChainID === connectedChainID)
         ) {
           return alert('Network connection issue; contact support')
-        }
-
-        const waitForInput = openWithdrawalConfirmationDialog()
-        const confirmed = await waitForInput()
-
-        if (!confirmed) {
-          return
         }
 
         if (selectedToken) {


### PR DESCRIPTION
In this PR:
* Show withdrawal confirmation dialog before attempting a network switch (https://github.com/OffchainLabs/arb-token-bridge/commit/a12965afd8a83abbfa914d3fd765b022489ca425)
* Wrap `TransferPanel` and `ExploreArbitrum` into separate `AnimatePresence` components as the `exitBeforeEnter` prop was causing only one of those to render, effectively cancelling the transfer (https://github.com/OffchainLabs/arb-token-bridge/commit/f555c1736856adb7a656bdae1cbc9345b20aee6f)
* Don't wait for pending withdrawals to load before rendering cards (withdrawals will now be loaded from local cache and show `Calculating...` until fetched from subgraph/logs and the wait time is calculated) (https://github.com/OffchainLabs/arb-token-bridge/commit/68756eac8a8d2fd2d502d3b259af0f97b2d69c7a)