### PR TITLE
fix: disable interaction while switching L2 chain

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -36,6 +36,7 @@ import {
   TransferPanelMain,
   TransferPanelMainErrorMessage
 } from './TransferPanelMain'
+import { useIsSwitchingL2Chain } from './TransferPanelMainUtils'
 
 const isAllowedL2 = async (
   arbTokenBridge: ArbTokenBridge,
@@ -120,6 +121,7 @@ export function TransferPanel() {
   const [l1Amount, setL1AmountState] = useState<string>('')
   const [l2Amount, setL2AmountState] = useState<string>('')
 
+  const isSwitchingL2Chain = useIsSwitchingL2Chain()
   const { shouldRequireApprove } = useL2Approve()
 
   const [
@@ -671,12 +673,22 @@ export function TransferPanel() {
   ])
 
   const isSummaryVisible = useMemo(() => {
+    if (isSwitchingL2Chain) {
+      return false
+    }
+
     if (transferring) {
       return true
     }
 
     return !(isDepositMode ? disableDeposit : disableWithdrawal)
-  }, [transferring, isDepositMode, disableDeposit, disableWithdrawal])
+  }, [
+    isSwitchingL2Chain,
+    transferring,
+    isDepositMode,
+    disableDeposit,
+    disableWithdrawal
+  ])
 
   return (
     <>
@@ -738,7 +750,7 @@ export function TransferPanel() {
             <Button
               variant="primary"
               loading={transferring}
-              disabled={disableDepositV2}
+              disabled={isSwitchingL2Chain || disableDepositV2}
               onClick={() => {
                 if (selectedToken) {
                   depositToken()
@@ -757,7 +769,7 @@ export function TransferPanel() {
             <Button
               variant="primary"
               loading={transferring}
-              disabled={disableWithdrawalV2}
+              disabled={isSwitchingL2Chain || disableWithdrawalV2}
               onClick={transfer}
               className="w-full bg-purple-ethereum py-4 text-lg lg:text-2xl"
             >

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -22,6 +22,7 @@ import { TransferPanelMainInput } from './TransferPanelMainInput'
 import {
   calculateEstimatedL1GasFees,
   calculateEstimatedL2GasFees,
+  useIsSwitchingL2Chain,
   useETHBalances,
   useTokenBalances
 } from './TransferPanelMainUtils'
@@ -192,13 +193,17 @@ function NetworkContainer({
   return (
     <div className={`rounded-xl p-2 transition-colors ${backgroundClassName}`}>
       <div
-        className="space-y-3.5 bg-contain bg-no-repeat px-4 py-1.5 sm:flex-row"
+        className="space-y-3.5 bg-contain bg-no-repeat p-1.5 sm:flex-row"
         style={{ backgroundImage }}
       >
         {children}
       </div>
     </div>
   )
+}
+
+function StyledLoader() {
+  return <Loader type="TailSpin" color="white" height={16} width={16} />
 }
 
 function ETHBalance({
@@ -212,7 +217,7 @@ function ETHBalance({
   const balance = balances[on]
 
   if (!balance) {
-    return <Loader type="TailSpin" color="white" height={16} width={16} />
+    return <StyledLoader />
   }
 
   return (
@@ -240,7 +245,7 @@ function TokenBalance({
   }
 
   if (!balance) {
-    return <Loader type="TailSpin" color="white" height={16} width={16} />
+    return <StyledLoader />
   }
 
   return (
@@ -291,6 +296,8 @@ export function TransferPanelMain({
 
   const { app } = useAppState()
   const { arbTokenBridge, isDepositMode, selectedToken } = app
+
+  const isSwitchingL2Chain = useIsSwitchingL2Chain()
 
   const ethBalances = useETHBalances()
   const tokenBalances = useTokenBalances(selectedToken?.address)
@@ -527,15 +534,21 @@ export function TransferPanelMain({
         <NetworkListboxPlusBalancesContainer>
           <NetworkListbox label="From:" {...networkListboxProps.from} />
           <BalancesContainer>
-            <TokenBalance
-              on={app.isDepositMode ? 'ethereum' : 'arbitrum'}
-              forToken={selectedToken}
-              prefix={selectedToken ? 'Balance: ' : ''}
-            />
-            <ETHBalance
-              on={app.isDepositMode ? 'ethereum' : 'arbitrum'}
-              prefix={selectedToken ? '' : 'Balance: '}
-            />
+            {isSwitchingL2Chain ? (
+              <StyledLoader />
+            ) : (
+              <>
+                <TokenBalance
+                  on={app.isDepositMode ? 'ethereum' : 'arbitrum'}
+                  forToken={selectedToken}
+                  prefix={selectedToken ? 'Balance: ' : ''}
+                />
+                <ETHBalance
+                  on={app.isDepositMode ? 'ethereum' : 'arbitrum'}
+                  prefix={selectedToken ? '' : 'Balance: '}
+                />
+              </>
+            )}
           </BalancesContainer>
         </NetworkListboxPlusBalancesContainer>
 
@@ -547,6 +560,7 @@ export function TransferPanelMain({
               onClick: setMaxAmount
             }}
             errorMessage={errorMessageText}
+            disabled={isSwitchingL2Chain}
             value={amount}
             onChange={e => setAmount(e.target.value)}
           />
@@ -575,15 +589,21 @@ export function TransferPanelMain({
         <NetworkListboxPlusBalancesContainer>
           <NetworkListbox label="To:" {...networkListboxProps.to} />
           <BalancesContainer>
-            <TokenBalance
-              on={app.isDepositMode ? 'arbitrum' : 'ethereum'}
-              forToken={selectedToken}
-              prefix={selectedToken ? 'Balance: ' : ''}
-            />
-            <ETHBalance
-              on={app.isDepositMode ? 'arbitrum' : 'ethereum'}
-              prefix={selectedToken ? '' : 'Balance: '}
-            />
+            {isSwitchingL2Chain ? (
+              <StyledLoader />
+            ) : (
+              <>
+                <TokenBalance
+                  on={app.isDepositMode ? 'arbitrum' : 'ethereum'}
+                  forToken={selectedToken}
+                  prefix={selectedToken ? 'Balance: ' : ''}
+                />
+                <ETHBalance
+                  on={app.isDepositMode ? 'arbitrum' : 'ethereum'}
+                  prefix={selectedToken ? '' : 'Balance: '}
+                />
+              </>
+            )}
           </BalancesContainer>
         </NetworkListboxPlusBalancesContainer>
       </NetworkContainer>

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainUtils.ts
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMainUtils.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
 import { BigNumber, utils } from 'ethers'
 
 import { useAppState } from '../../state'
+import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
 
 export function calculateEstimatedL1GasFees(
   estimatedL1Gas: BigNumber,
@@ -71,4 +73,29 @@ export function useTokenBalances(erc20L1Address?: string): Balances {
       arbitrum: tokenBalances.arbChainBalance
     }
   }, [arbTokenBridge, erc20L1Address])
+}
+
+export function useIsSwitchingL2Chain() {
+  const { app } = useAppState()
+  const { isDepositMode } = app
+
+  const { l2, isConnectedToArbitrum } = useNetworksAndSigners()
+
+  const { search } = useLocation()
+  const searchParams = new URLSearchParams(search)
+  const l2ChainIdSearchParam = searchParams.get('l2ChainId')
+
+  return useMemo(() => {
+    if (isConnectedToArbitrum || !isDepositMode) {
+      return false
+    }
+
+    const parsedL2ChainId = parseInt(l2ChainIdSearchParam || '')
+
+    if (isNaN(parsedL2ChainId)) {
+      return false
+    }
+
+    return l2.network.chainID !== parsedL2ChainId
+  }, [isConnectedToArbitrum, isDepositMode, l2, l2ChainIdSearchParam])
 }


### PR DESCRIPTION
Disables UI elements like the main input, buttons to move funds and the gas summary in the few seconds while the switch between different L2s is happening.