### PR TITLE
fix: set the connected L2 chain as the preferred one

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -312,9 +312,19 @@ export function TransferPanelMain({
   const [withdrawOnlyDialogProps, openWithdrawOnlyDialog] = useDialog()
 
   useEffect(() => {
+    const l2ChainId = isConnectedToArbitrum
+      ? externalFrom.chainID
+      : externalTo.chainID
+
     setFrom(externalFrom)
     setTo(externalTo)
-  }, [externalFrom, externalTo])
+
+    // Keep the connected L2 chain id in search params, so it takes preference in any L1 => L2 actions
+    history.replace({
+      pathname: '/',
+      search: `?l2ChainId=${l2ChainId}`
+    })
+  }, [isConnectedToArbitrum, externalFrom, externalTo, history])
 
   const maxButtonVisible = useMemo(() => {
     const ethBalance = isDepositMode


### PR DESCRIPTION
If the user was connected to Arbitrum Nova in their wallet, and they set up everything for a deposit (rightfully expecting the deposit to land to Arbitrum Nova), the bridge would prompt a switch to Mainnet in order to confirm the deposit. 

Problem: no `l2ChainId` search param would be present, and the preferred L2 would default to the first one, i.e. Arbitrum One.