### PR TITLE
add arb1 shadowfork support

### DIFF
--- a/packages/arb-token-bridge-ui/src/index.tsx
+++ b/packages/arb-token-bridge-ui/src/index.tsx
@@ -4,7 +4,7 @@ import { BrowserTracing } from '@sentry/tracing'
 
 import App from './components/App/App'
 import reportWebVitals from './reportWebVitals'
-import { registerLocalNetwork } from './util/networks'
+import { addShadowFork, registerLocalNetwork } from './util/networks'
 
 import Package from '../package.json'
 
@@ -24,7 +24,15 @@ Sentry.init({
   tracesSampleRate: 0.5
 })
 
-ReactDOM.render(<App />, document.getElementById('root'))
+async function main() {
+  await addShadowFork()
+    .then(isNitro => console.log(`Shadow fork registered. isNitro: ${isNitro}`))
+    .catch(err => console.error(`error adding shadow fork ${err}`))
+  ReactDOM.render(<App />, document.getElementById('root'))
+}
+
+main()
+
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -211,7 +211,7 @@ export const useArbTokenBridge = (
   ] = useTransactions()
 
   const isRinkeby = l1.network.chainID === 4
-  const isArbitrumOne = l1.network.chainID === 42161
+  const isArbitrumOne = l2.network.chainID === 42161
   
   const l1NetworkID = useMemo(() => String(l1.network.chainID), [l1.network])
   const l2NetworkID = useMemo(() => String(l2.network.chainID), [l2.network])

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -211,7 +211,7 @@ export const useArbTokenBridge = (
   ] = useTransactions()
 
   const isRinkeby = l1.network.chainID === 4
-  const isArbitrumOne = l2.network.chainID === 42161
+  const isArbitrumOne = l2.network.chainID === 42161 || l2.network.chainID === 412346
   
   const l1NetworkID = useMemo(() => String(l1.network.chainID), [l1.network])
   const l2NetworkID = useMemo(() => String(l2.network.chainID), [l2.network])

--- a/packages/token-bridge-sdk/src/util/graph.ts
+++ b/packages/token-bridge-sdk/src/util/graph.ts
@@ -53,6 +53,7 @@ const apolloL2GatewaysClient = new ApolloClient({
 const networkIDAndLayerToClient = (networkID: string, layer: 1 | 2) => {
   switch (networkID) {
     case '1':
+    case '1337':
       return layer === 1 ? apolloL1Mainnetlient : apolloL2Mainnetlient
     case '4':
       return layer === 1 ? apolloL1RinkebyClient : apolloL2RinkebyClient
@@ -199,6 +200,7 @@ export const getTokenWithdrawals = async (
   const client = ((l1NetworkID: string) => {
     switch (l1NetworkID) {
       case '1':
+      case '1337':
         return apolloL2GatewaysClient
       case '4':
         return apolloL2GatewaysRinkebyClient
@@ -310,6 +312,7 @@ export const getBuiltInsGraphLatestBlockNumber = (l1NetworkID: string) => {
   const subgraphName = ((l1NetworkID: string) => {
     switch (l1NetworkID) {
       case '1':
+      case '1337':
         return 'fredlacs/arb-builtins'
       case '4':
         return 'fredlacs/arb-builtins-rinkeby'
@@ -325,6 +328,7 @@ export const getL2GatewayGraphLatestBlockNumber = (l1NetworkID: string) => {
   const subgraphName = ((l1NetworkID: string) => {
     switch (l1NetworkID) {
       case '1':
+      case '1337':
         return 'fredlacs/layer2-token-gateway'
       case '4':
         return 'fredlacs/layer2-token-gateway-rinkeby'


### PR DESCRIPTION
implementation done based off previous work from https://github.com/OffchainLabs/arb-token-bridge/commit/36f6a8f7512dfc12137101bbbe1278b297bc33b2 (diff easier to view in [here](https://github.com/OffchainLabs/arb-token-bridge/compare/rinkeby-nitro-migration-subgraph-shadowfork))

relies on https://github.com/OffchainLabs/arb-token-bridge/pull/399