### PR TITLE
feat: add unstoppable domains support

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -10,6 +10,7 @@
     "@sentry/tracing": "^7.9.0",
     "@tailwindcss/forms": "^0.3.3",
     "@tippyjs/react": "^4.2.6",
+    "@unstoppabledomains/resolution": "^8.3.3",
     "@walletconnect/web3-provider": "^1.6.5",
     "axios": "^0.21.4",
     "boring-avatars": "^1.7.0",

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -61,9 +61,9 @@ function isDeposit(tx: MergedTransaction) {
 
 async function tryLookupUDName(provider: JsonRpcProvider, address: string) {
   const UDresolution = Resolution.fromEthersProvider({uns: {
+    // TODO => remove Layer2 config when UD lib supports our use case
     // Layer2 (polygon) is required in the object type but we only want to use Layer1
     // This is a hack to only support Ethereum Mainnet UD names
-    // TODO => remove Layer2 config when UD lib supports our use case
     // https://github.com/unstoppabledomains/resolution/issues/229
     locations: {
       Layer1: {
@@ -83,7 +83,7 @@ async function tryLookupUDName(provider: JsonRpcProvider, address: string) {
   }
 }
 
-async function tryLookupAddress(
+async function tryLookupENSName(
   provider: JsonRpcProvider,
   address: string
 ): Promise<string | null> {
@@ -94,7 +94,7 @@ async function tryLookupAddress(
   }
 }
 
-async function tryGetAvatar(
+async function tryLookupENSAvatar(
   provider: JsonRpcProvider,
   address: string
 ): Promise<string | null> {
@@ -121,8 +121,8 @@ export function HeaderAccountPopover() {
     async function resolveNameServiceInfo() {
       if (account && l1.signer) {
         const [ensName, avatar, udName] = await Promise.all([
-          tryLookupAddress(l1.signer.provider, account),
-          tryGetAvatar(l1.signer.provider, account),
+          tryLookupENSName(l1.signer.provider, account),
+          tryLookupENSAvatar(l1.signer.provider, account),
           tryLookupUDName(l1.signer.provider, account)
         ])
         setENSInfo({ name: ensName, avatar })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,7 +1546,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
-"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.0.0", "@ethersproject/abi@^5.6.3", "@ethersproject/abi@^5.7.0":
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.0.0", "@ethersproject/abi@^5.0.1", "@ethersproject/abi@^5.6.3", "@ethersproject/abi@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
   integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
@@ -2872,7 +2872,7 @@
     penpal "3.0.7"
     pocket-js-core "0.0.3"
 
-"@rehooks/local-storage@^2.3.0":
+"@rehooks/local-storage@2.4.0", "@rehooks/local-storage@^2.3.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@rehooks/local-storage/-/local-storage-2.4.0.tgz#fb884b2b657cad5f77aa6ab60bb3532f0e0725d2"
   integrity sha512-LoXDbEHsuIckVgBsFAv8SuU/M7memjyfWut9Zf36TQXqqCHBRFv8bweg9PymQCa1aWIMjNrZQflFdo55FDlXYg==
@@ -4259,6 +4259,17 @@
   version "1.0.0-beta.28"
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.28.tgz#76bb6ec25e76ae6bece9efc11b9b68079b2b9402"
   integrity sha512-MmVeoOd/HlZYOn5NT2mlDoOUYjnZb+3V7aCD5/YwSgsqeDRXZmKfKHafEEhiZoMvXuZdqSBg4L/ythvzAf9cwA==
+
+"@unstoppabledomains/resolution@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-8.3.3.tgz#599c5e2f068a36e24bd19c0f9e2f753036264a3b"
+  integrity sha512-jQ9757Lvx/xqU7Lg7JT4L9WQZuElHkMiJmtph0e6TSwfguIlkv1i5UgzURgVXDvVizVKpDejGS60kuvICkz9ZQ==
+  dependencies:
+    "@ethersproject/abi" "^5.0.1"
+    bn.js "^4.4.0"
+    cross-fetch "^3.1.4"
+    crypto-js "^4.1.1"
+    elliptic "^6.5.4"
 
 "@walletconnect/browser-utils@^1.7.7":
   version "1.7.7"
@@ -8022,6 +8033,13 @@ cross-fetch@^2.1.1:
     node-fetch "^2.6.7"
     whatwg-fetch "^2.0.4"
 
+cross-fetch@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -8076,6 +8094,11 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -15634,7 +15657,7 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
This PR only supports UD on Ethereum mainnet and not the ones on Polygon.

#### Local test
Development was done using Polygon UD
Polygon Mainnet address provided by Unstoppable:
> Here's a test address for mainnet `0x499dD6D875787869670900a2130223D85d4F6Aa7` with reverse resolution configured

To know if an address has reverse resolution set up, check that `reverseOf` returns the token id
Polygon: https://polygonscan.com/address/0x3E67b8c702a1292d1CEb025494C84367fcb12b45#readContract
Mainnet: https://etherscan.io/address/0x049aba7510f45BA5b64ea9E658E342F904DB358D#readProxyContract

![image](https://user-images.githubusercontent.com/13184582/190369260-8372a2ce-2eba-42de-916d-8b3a4969cb62.png)
