### PR TITLE
refactor: move balance logic from useArbTokenBridge to its own context

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -14,7 +14,8 @@ import {
 } from 'react-router-dom'
 import { useLocalStorage } from 'react-use'
 import { ConnectionState } from 'src/util/index'
-import { TokenBridgeParams } from 'token-bridge-sdk'
+import { BalanceProvider, TokenBridgeParams } from 'token-bridge-sdk'
+
 import { L1Network, L2Network } from '@arbitrum/sdk'
 import { ExternalProvider, JsonRpcProvider } from '@ethersproject/providers'
 import Loader from 'react-loader-spinner'
@@ -363,7 +364,9 @@ function Routes() {
         <Route path="/" exact>
           <NetworkReady>
             <AppContextProvider>
-              <Injector>{isTosAccepted && <AppContent />}</Injector>
+              <BalanceProvider>
+                <Injector>{isTosAccepted && <AppContent />}</Injector>
+              </BalanceProvider>
             </AppContextProvider>
           </NetworkReady>
         </Route>

--- a/packages/token-bridge-sdk/src/context/balanceContext.tsx
+++ b/packages/token-bridge-sdk/src/context/balanceContext.tsx
@@ -1,0 +1,98 @@
+import {
+  createContext,
+  useContext,
+  useReducer,
+  PropsWithChildren,
+  useCallback
+} from 'react'
+import { ArbTokenBridgeBalances } from '../hooks/arbTokenBridge.types'
+
+const initialState: ArbTokenBridgeBalances = {
+  eth: {
+    arbChainBalance: null,
+    balance: null
+  },
+  erc20: {},
+  erc721: {}
+}
+
+type SetEthBalancesPayload = ArbTokenBridgeBalances['eth']
+type SetEthBalancesAction = {
+  type: 'setEthBalances'
+  payload: SetEthBalancesPayload
+}
+type SetErc20BalancesPayload = ArbTokenBridgeBalances['erc20']
+type SetErc20BalancesAction = {
+  type: 'setErc20Balance'
+  payload: SetErc20BalancesPayload
+}
+type Action = SetEthBalancesAction | SetErc20BalancesAction
+
+type BalanceContextValue = [
+  ArbTokenBridgeBalances,
+  (payload: SetEthBalancesPayload) => void,
+  (payload: SetErc20BalancesPayload) => void
+]
+
+const BalanceContext = createContext<BalanceContextValue>([
+  initialState,
+  () => {},
+  () => {}
+])
+
+function balanceReducer(state: ArbTokenBridgeBalances, action: Action) {
+  switch (action.type) {
+    case 'setEthBalances':
+      return {
+        ...state,
+        eth: action.payload
+      }
+    case 'setErc20Balance':
+      return {
+        ...state,
+        ...action.payload
+      }
+  }
+}
+
+function BalanceProvider({ children }: PropsWithChildren<{}>) {
+  const [state, dispatch] = useReducer(balanceReducer, initialState)
+  const setEthBalances = useCallback(
+    ({ arbChainBalance, balance }: SetEthBalancesPayload) =>
+      dispatch({
+        type: 'setEthBalances',
+        payload: {
+          arbChainBalance,
+          balance
+        }
+      }),
+    [dispatch]
+  )
+
+  const setErc20Balances = useCallback(
+    (updatedBalances: SetErc20BalancesPayload) =>
+      dispatch({
+        type: 'setErc20Balance',
+        payload: updatedBalances
+      }),
+    [dispatch]
+  )
+
+  return (
+    <BalanceContext.Provider value={[state, setEthBalances, setErc20Balances]}>
+      {children}
+    </BalanceContext.Provider>
+  )
+}
+
+function useBalanceContext() {
+  const context = useContext(BalanceContext)
+
+  if (context === undefined) {
+    throw new Error('useBalanceContext must be used within a BalanceProvider')
+  }
+
+  return context
+}
+
+export { BalanceProvider, useBalanceContext }

--- a/packages/token-bridge-sdk/src/index.ts
+++ b/packages/token-bridge-sdk/src/index.ts
@@ -35,3 +35,5 @@ export { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__fact
 
 export { validateTokenList } from './util/index'
 export { getUniqueIdOrHashFromEvent } from './util/migration'
+
+export { BalanceProvider, useBalanceContext } from './context/balanceContext'

--- a/packages/token-bridge-sdk/tsconfig.json
+++ b/packages/token-bridge-sdk/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "declaration": true,
@@ -18,11 +14,9 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true,
     "baseUrl": "src"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Moved balance related logic from `useArbTokenBridge` to its own context.

No breaking changes