### PR TITLE
refactor: enable eth balance fetch retries in useBalance

### DIFF
--- a/packages/arb-token-bridge-ui/src/index.tsx
+++ b/packages/arb-token-bridge-ui/src/index.tsx
@@ -23,12 +23,15 @@ Sentry.init({
   integrations: [new BrowserTracing()],
   tracesSampleRate: 0.15,
   beforeSend: event => {
-    if (
-      event.message &&
-      // Ignore events related to failed `eth_gasPrice` calls
-      event.message.match(/eth_gasPrice/i)
-    ) {
-      return null
+    if (event.message) {
+      if (
+        // Ignore events related to failed `eth_gasPrice` calls
+        event.message.match(/eth_gasPrice/i) ||
+        // Ignore events related to failed `eth_getBalance` calls
+        event.message.match(/eth_getBalance/i)
+      ) {
+        return null
+      }
     }
 
     return event

--- a/packages/token-bridge-sdk/src/hooks/useBalance.ts
+++ b/packages/token-bridge-sdk/src/hooks/useBalance.ts
@@ -21,21 +21,29 @@ const useBalance = ({
 
   let safeBalance: { eth: BigNumber | null } = defaultBalance
 
-  if (typeof walletAddress !== 'undefined' && typeof chainId !== 'undefined') {
-    safeBalance = balances[walletAddress]?.[chainId] ?? defaultBalance
-  }
+  const walletAddressLowercased = useMemo(
+    () => walletAddress?.toLowerCase(),
+    [walletAddress]
+  )
 
   const queryKey = useMemo(() => {
     if (
       typeof chainId === 'undefined' ||
-      typeof walletAddress === 'undefined'
+      typeof walletAddressLowercased === 'undefined'
     ) {
       // Don't fetch
       return null
     }
 
-    return ['ethBalance', chainId, walletAddress.toLowerCase()]
-  }, [chainId, walletAddress])
+    return ['ethBalance', chainId, walletAddressLowercased]
+  }, [chainId, walletAddressLowercased])
+
+  if (
+    typeof walletAddressLowercased !== 'undefined' &&
+    typeof chainId !== 'undefined'
+  ) {
+    safeBalance = balances[walletAddressLowercased]?.[chainId] ?? defaultBalance
+  }
 
   const { mutate } = useSWR(
     queryKey,

--- a/packages/token-bridge-sdk/src/hooks/useBalance.ts
+++ b/packages/token-bridge-sdk/src/hooks/useBalance.ts
@@ -40,13 +40,11 @@ const useBalance = ({
   const { mutate } = useSWR(
     queryKey,
     async (_, _chainId: number, _walletAddress: string) => {
-      const newBalance = await provider.getBalance(_walletAddress)
-
       setBalances({
         walletAddress: _walletAddress,
         chainId: _chainId,
         type: 'eth',
-        balance: newBalance
+        balance: await provider.getBalance(_walletAddress)
       })
     },
     {

--- a/packages/token-bridge-sdk/src/hooks/useBalance.ts
+++ b/packages/token-bridge-sdk/src/hooks/useBalance.ts
@@ -48,10 +48,10 @@ const useBalance = ({
       })
     },
     {
-      refreshInterval: 5_000,
+      refreshInterval: 15_000,
       shouldRetryOnError: true,
-      errorRetryCount: 1,
-      errorRetryInterval: 1_000
+      errorRetryCount: 2,
+      errorRetryInterval: 3_000
     }
   )
 

--- a/packages/token-bridge-sdk/src/hooks/useBalance.ts
+++ b/packages/token-bridge-sdk/src/hooks/useBalance.ts
@@ -40,7 +40,6 @@ const useBalance = ({
   const { mutate } = useSWR(
     queryKey,
     async (_, _chainId: number, _walletAddress: string) => {
-      console.log('refetching')
       const newBalance = await provider.getBalance(_walletAddress)
 
       setBalances({

--- a/packages/token-bridge-sdk/src/hooks/useChainId.ts
+++ b/packages/token-bridge-sdk/src/hooks/useChainId.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react'
+import { providers } from 'ethers'
+
+export function useChainId({ provider }: { provider: providers.Provider }) {
+  const [chainId, setChainId] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    async function updateChainId() {
+      setChainId((await provider.getNetwork()).chainId)
+    }
+
+    updateChainId()
+  }, [provider])
+
+  return chainId
+}

--- a/packages/token-bridge-sdk/src/hooks/useGasPrice.ts
+++ b/packages/token-bridge-sdk/src/hooks/useGasPrice.ts
@@ -1,24 +1,18 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { BigNumber, providers } from 'ethers'
 import useSWR from 'swr'
+
+import { useChainId } from './useChainId'
 
 export function useGasPrice({
   provider
 }: {
   provider: providers.Provider
 }): BigNumber {
-  const [chainId, setChainId] = useState<number | null>(null)
-
-  useEffect(() => {
-    async function updateChainId() {
-      setChainId((await provider.getNetwork()).chainId)
-    }
-
-    updateChainId()
-  }, [provider])
+  const chainId = useChainId({ provider })
 
   const queryKey = useMemo(() => {
-    if (chainId === null) {
+    if (typeof chainId === 'undefined') {
       // Don't fetch
       return null
     }


### PR DESCRIPTION
In this PR:
* Created a new hook `useChainId` which is useful when using the chain id from provider as a query key in `useSWR`
* Modified `useBalance` a bit so it doesn't catch errors thrown in the fetcher; retries now work properly
* Ignored errors related to `eth_getBalance` in Sentry