### PR TITLE
feat: change withdrawal calendar to be hour based

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
@@ -31,7 +31,8 @@ function getCalendarUrl(
 ) {
   const title = `${amount} ${token} Withdrawal from ${networkName}`
 
-  const withdrawalDate = dayjs().add(confirmationHours, 'hour')
+  // Add 1 extra hour to account for remaining minutes
+  const withdrawalDate = dayjs().add(confirmationHours + 1, 'hour')
   // Google event date format: YYYYMMDDTHHMMSS/YYYYMMDDTHHMMSS
   const parsedWithdrawalDate = withdrawalDate.format(
     'YYYYMMDD[T]HH[0000%2F]YYYYMMDD[T]HH[0000]'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
@@ -24,14 +24,21 @@ const SECONDS_IN_DAY = 86400
 const SECONDS_IN_HOUR = 3600
 
 function getCalendarUrl(
-  confirmationDays: number,
+  confirmationHours: number,
   amount: string,
   token: string,
   networkName: string
 ) {
   const title = `${amount} ${token} Withdrawal from ${networkName}`
-  const withdrawalDate = dayjs().add(confirmationDays, 'day').format('YYYYMMDD')
-  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${withdrawalDate}%2F${withdrawalDate}`
+
+  // Add 1 extra hour to account for remaining minutes
+  const withdrawalDate = dayjs().add(confirmationHours + 1, 'hour')
+  // Google event date format: YYYYMMDDTHHMMSS/YYYYMMDDTHHMMSS
+  const parsedWithdrawalDate = withdrawalDate.format(
+    'YYYYMMDD[T]HH[0000%2F]YYYYMMDD[T]HH[0000]'
+  )
+
+  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${parsedWithdrawalDate}`
 }
 
 export function WithdrawalConfirmationDialog(
@@ -60,13 +67,13 @@ export function WithdrawalConfirmationDialog(
     l1.network.blockTime * l2.network.confirmPeriodBlocks
   const confirmationDays = Math.ceil(confirmationSeconds / SECONDS_IN_DAY)
   let confirmationPeriod = ''
+  const confirmationHours = Math.ceil(confirmationSeconds / SECONDS_IN_HOUR)
 
   if (confirmationDays >= 2) {
     confirmationPeriod = `${confirmationDays} day${
       confirmationDays > 1 ? 's' : ''
     }`
   } else {
-    const confirmationHours = Math.round(confirmationSeconds / SECONDS_IN_HOUR)
     confirmationPeriod = `${confirmationHours} hour${
       confirmationHours > 1 ? 's' : ''
     }`
@@ -186,7 +193,7 @@ export function WithdrawalConfirmationDialog(
                   <div className="flex justify-center">
                     <ExternalLink
                       href={getCalendarUrl(
-                        confirmationDays,
+                        confirmationHours,
                         props.amount,
                         selectedToken?.symbol || 'ETH',
                         getNetworkName(l2.network)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
@@ -31,8 +31,7 @@ function getCalendarUrl(
 ) {
   const title = `${amount} ${token} Withdrawal from ${networkName}`
 
-  // Add 1 extra hour to account for remaining minutes
-  const withdrawalDate = dayjs().add(confirmationHours + 1, 'hour')
+  const withdrawalDate = dayjs().add(confirmationHours, 'hour')
   // Google event date format: YYYYMMDDTHHMMSS/YYYYMMDDTHHMMSS
   const parsedWithdrawalDate = withdrawalDate.format(
     'YYYYMMDD[T]HH[0000%2F]YYYYMMDD[T]HH[0000]'

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
@@ -38,7 +38,7 @@ function getCalendarUrl(
     'YYYYMMDD[T]HH[0000%2F]YYYYMMDD[T]HH[0000]'
   )
 
-  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${parsedWithdrawalDate}`
+  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${parsedWithdrawalDate}&details=Withdrawn+on+%3Ca%20href=%22https://bridge.arbitrum.io%22%3Ehttps://bridge.arbitrum.io%3C/a%3E`
 }
 
 export function WithdrawalConfirmationDialog(


### PR DESCRIPTION
Changed withdrawal calculation to be based on hours instead of days. That's also the case if withdrawal time is longer than a day.