### PR TITLE
(investigating) fix: pass actual amount and fallback to 0 for token deposit gas estimation

### DIFF
--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -606,7 +606,7 @@ export const useArbTokenBridge = (
   }) {
     const depositRequest = await erc20Bridger.getDepositRequest({
       // Setting `amount` to zero so it doesn't fail on not enough allowance
-      amount: BigNumber.from(0),
+      amount: amount ?? BigNumber.from(0),
       from: walletAddress,
       erc20L1Address,
       l1Provider: l1.provider,


### PR DESCRIPTION
Flagged by @bartlomiej94 
This does not fix the issue when the user is using Metamask
Not sure why it works with Frame wallet

Issue:
When users want to deposit some ERC20 token
even though they have enough ETH in their wallet
gas estimation failed

<img width="585" alt="image" src="https://user-images.githubusercontent.com/13184582/194498638-2edb4e54-0ecf-4862-90cc-0f6c8d91d24e.png">

tested locally with Frame wallet with an address with LPT on mainnet
reproduced and fixed the issue