### PR TITLE
fix: lowercase token address when adding to token list

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -429,7 +429,7 @@ function TokensPanel({
   }, [tokensFromLists, tokensFromUser, newToken, getBalance])
 
   const storeNewToken = async () => {
-    return token.add(newToken).catch((ex: Error) => {
+    return token.add(newToken.toLowerCase()).catch((ex: Error) => {
       let error = 'Token not found on this network.'
 
       if (ex.name === 'TokenDisabledError') {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenSearch.tsx
@@ -429,7 +429,7 @@ function TokensPanel({
   }, [tokensFromLists, tokensFromUser, newToken, getBalance])
 
   const storeNewToken = async () => {
-    return token.add(newToken.toLowerCase()).catch((ex: Error) => {
+    return token.add(newToken).catch((ex: Error) => {
       let error = 'Token not found on this network.'
 
       if (ex.name === 'TokenDisabledError') {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -831,15 +831,16 @@ export const useArbTokenBridge = (
     let l1TokenBalance: BigNumber | null = null
     let l2TokenBalance: BigNumber | null = null
 
-    const maybeL1Address = await getL1ERC20Address(erc20L1orL2Address)
+    const lowercasedErc20L1orL2Address = erc20L1orL2Address.toLowerCase()
+    const maybeL1Address = await getL1ERC20Address(lowercasedErc20L1orL2Address)
 
     if (maybeL1Address) {
       // looks like l2 address was provided
       l1Address = maybeL1Address
-      l2Address = erc20L1orL2Address
+      l2Address = lowercasedErc20L1orL2Address
     } else {
       // looks like l1 address was provided
-      l1Address = erc20L1orL2Address
+      l1Address = lowercasedErc20L1orL2Address
       l2Address = await getL2ERC20Address(l1Address)
     }
 


### PR DESCRIPTION
This created an issue where Kyber token could be added twice and display an unknown token logo. Here we lowercase when adding new tokens for consistency and to avoid issues like that.

@spsjvc as per your request for the search bar to be case insensitive as well - that's already the case, no changes needed