### PR TITLE
refactor: only accept chain id as arg in `isNetwork`

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -87,7 +87,7 @@ const AppContent = (): JSX.Element => {
   } = useAppState()
 
   const headerOverridesProps: HeaderOverridesProps = useMemo(() => {
-    const { isMainnet, isRinkeby, isGoerli } = isNetwork(l1.network)
+    const { isMainnet, isRinkeby, isGoerli } = isNetwork(l1.network.chainID)
     const className = isMainnet ? 'lg:bg-black' : 'lg:bg-blue-arbitrum'
 
     if (isRinkeby) {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositConfirmationDialog.tsx
@@ -29,7 +29,7 @@ export function DepositConfirmationDialog(
   } = useAppState()
   const { l1, l2, isConnectedToArbitrum } = useNetworksAndSigners()
   const networkName = getNetworkName(l2.network.chainID)
-  const { isArbitrumOne } = isNetwork(l2.network)
+  const { isArbitrumOne } = isNetwork(l2.network.chainID)
 
   const [, copyToClipboard] = useCopyToClipboard()
   const [showCopied, setShowCopied] = useState(false)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/LowBalanceDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/LowBalanceDialog.tsx
@@ -79,7 +79,7 @@ export function LowBalanceDialog(props: UseDialogProps) {
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [isFormOpen, setIsFormOpen] = useState(false)
-  const { isMainnet } = isNetwork(l1.network)
+  const { isMainnet } = isNetwork(l1.network.chainID)
   const {
     eth: [ethBalance]
   } = useBalance({

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenApprovalDialog.tsx
@@ -26,7 +26,7 @@ export function TokenApprovalDialog(props: TokenApprovalDialogProps) {
   const { toUSD } = useETHPrice()
 
   const { l1 } = useNetworksAndSigners()
-  const { isMainnet } = isNetwork(l1.network)
+  const { isMainnet } = isNetwork(l1.network.chainID)
 
   const l1GasPrice = useGasPrice({ provider: l1.provider })
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -110,8 +110,8 @@ export function TransferPanel() {
   } = networksAndSigners
   const dispatch = useAppContextDispatch()
 
-  const { isMainnet } = isNetwork(l1Network)
-  const { isArbitrumNova } = isNetwork(l2Network)
+  const { isMainnet } = isNetwork(l1Network.chainID)
+  const { isArbitrumNova } = isNetwork(l2Network.chainID)
 
   const latestEth = useLatest(eth)
   const latestToken = useLatest(token)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -67,7 +67,7 @@ function NetworkListbox({
   onChange
 }: NetworkListboxProps) {
   const buttonClassName = useMemo(() => {
-    const { isArbitrum, isArbitrumNova } = isNetwork(value)
+    const { isArbitrum, isArbitrumNova } = isNetwork(value.chainID)
 
     if (!isArbitrum) {
       return 'bg-[rgba(118,121,145,0.8)]'
@@ -81,7 +81,7 @@ function NetworkListbox({
   }, [value])
 
   const getOptionImageSrc = useCallback((network: L1Network | L2Network) => {
-    const { isArbitrum, isArbitrumNova } = isNetwork(network)
+    const { isArbitrum, isArbitrumNova } = isNetwork(network.chainID)
 
     if (!isArbitrum) {
       return EthereumLogo
@@ -170,7 +170,7 @@ function NetworkContainer({
   children: React.ReactNode
 }) {
   const { backgroundImage, backgroundClassName } = useMemo(() => {
-    const { isArbitrum, isArbitrumNova } = isNetwork(network)
+    const { isArbitrum, isArbitrumNova } = isNetwork(network.chainID)
 
     if (!isArbitrum) {
       return {

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelSummary.tsx
@@ -243,7 +243,7 @@ export function TransferPanelSummary({
   const { toUSD } = useETHPrice()
   const { l1 } = useNetworksAndSigners()
 
-  const { isMainnet } = isNetwork(l1.network)
+  const { isMainnet } = isNetwork(l1.network.chainID)
 
   if (status === 'loading') {
     const bgClassName = app.isDepositMode

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalConfirmationDialog.tsx
@@ -79,7 +79,7 @@ export function WithdrawalConfirmationDialog(
     }`
   }
 
-  const { isArbitrumOne } = isNetwork(l2.network)
+  const { isArbitrumOne } = isNetwork(l2.network.chainID)
 
   function closeWithReset(confirmed: boolean) {
     props.onClose(confirmed)

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
@@ -20,7 +20,7 @@ export function HeaderNetworkInformation() {
   )
 
   const logoSrc = useMemo(() => {
-    const { isArbitrum, isArbitrumNova } = isNetwork(network)
+    const { isArbitrum, isArbitrumNova } = isNetwork(network.chainID)
 
     if (!isArbitrum) {
       return EthereumLogo

--- a/packages/arb-token-bridge-ui/src/components/common/Notifications.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Notifications.tsx
@@ -73,7 +73,7 @@ function NitroDevnetNotification() {
 
 export function Notifications() {
   const { l1 } = useNetworksAndSigners()
-  const { isMainnet, isRinkeby, isGoerli } = isNetwork(l1.network)
+  const { isMainnet, isRinkeby, isGoerli } = isNetwork(l1.network.chainID)
 
   return (
     <NotificationContainer>

--- a/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/WithdrawalCountdown.tsx
@@ -25,7 +25,7 @@ export function WithdrawalCountdown({
   }
 
   if (nodeBlockDeadline === 'NODE_NOT_CREATED') {
-    const { isMainnet } = isNetwork(l1Network)
+    const { isMainnet } = isNetwork(l1Network.chainID)
     return <span>{isMainnet ? '~1 week' : '~1 day'} remaining</span>
   }
 

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -117,9 +117,7 @@ export function registerLocalNetwork() {
   }
 }
 
-export function isNetwork(network: L1Network | L2Network) {
-  const chainId = network.chainID
-
+export function isNetwork(chainId: ChainId) {
   return {
     // L1
     isMainnet: chainId === ChainId.Mainnet,
@@ -127,7 +125,8 @@ export function isNetwork(network: L1Network | L2Network) {
     isRinkeby: chainId === ChainId.Rinkeby,
     isGoerli: chainId === ChainId.Goerli,
     // L2
-    isArbitrum: Boolean((network as any).isArbitrum),
+    isArbitrum:
+      chainId === ChainId.ArbitrumOne || chainId === ChainId.ArbitrumNova,
     isArbitrumOne: chainId === ChainId.ArbitrumOne,
     isArbitrumNova: chainId === ChainId.ArbitrumNova,
     // L2 Testnets

--- a/packages/arb-token-bridge-ui/src/util/networks.ts
+++ b/packages/arb-token-bridge-ui/src/util/networks.ts
@@ -126,7 +126,10 @@ export function isNetwork(chainId: ChainId) {
     isGoerli: chainId === ChainId.Goerli,
     // L2
     isArbitrum:
-      chainId === ChainId.ArbitrumOne || chainId === ChainId.ArbitrumNova,
+      chainId === ChainId.ArbitrumOne ||
+      chainId === ChainId.ArbitrumNova ||
+      chainId === ChainId.ArbitrumGoerli ||
+      chainId === ChainId.ArbitrumRinkeby,
     isArbitrumOne: chainId === ChainId.ArbitrumOne,
     isArbitrumNova: chainId === ChainId.ArbitrumNova,
     // L2 Testnets


### PR DESCRIPTION
- [x] Refactor `isNetwork` (networks.ts) so it only accepts `chainId` instead of a network object