### PR TITLE
fix: react unmount errors

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
@@ -15,6 +15,7 @@ type AppContextState = {
   seenTransactions: string[]
   layout: {
     isTransferPanelVisible: boolean
+    isTransferring: boolean
   }
 }
 
@@ -22,7 +23,8 @@ const initialState: AppContextState = {
   currentL1BlockNumber: 0,
   seenTransactions: SeenTransactionsCache.get(),
   layout: {
-    isTransferPanelVisible: true
+    isTransferPanelVisible: true,
+    isTransferring: false
   }
 }
 
@@ -34,6 +36,7 @@ type Action =
   | { type: 'set_current_l1_block_number'; payload: number }
   | { type: 'set_tx_as_seen'; payload: string }
   | { type: 'layout.set_is_transfer_panel_visible'; payload: boolean }
+  | { type: 'layout.set_is_transferring'; payload: boolean }
 
 function reducer(state: AppContextState, action: Action) {
   switch (action.type) {
@@ -55,6 +58,12 @@ function reducer(state: AppContextState, action: Action) {
       return {
         ...state,
         layout: { ...state.layout, isTransferPanelVisible: action.payload }
+      }
+
+    case 'layout.set_is_transferring':
+      return {
+        ...state,
+        layout: { ...state.layout, isTransferring: action.payload }
       }
 
     default:

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -292,7 +292,7 @@ export function TransferPanel() {
     const dialogType = getDialogType()
 
     if (dialogType) {
-      if (!isTransferring) setTokenDepositCheckDialogType(dialogType)
+      setTokenDepositCheckDialogType(dialogType)
 
       const waitForInput = openTokenCheckDialog()
       const confirmed = await waitForInput()

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -313,7 +313,10 @@ export function TransferPanel() {
       return
     }
 
-    dispatch({ type: 'layout.set_is_transferring', payload: true })
+    const setTransferring = (payload: boolean) =>
+      dispatch({ type: 'layout.set_is_transferring', payload })
+
+    setTransferring(true)
 
     try {
       if (isDepositMode) {
@@ -417,6 +420,7 @@ export function TransferPanel() {
                   type: 'layout.set_is_transfer_panel_visible',
                   payload: false
                 })
+                setTransferring(false)
               }
             }
           })
@@ -432,6 +436,7 @@ export function TransferPanel() {
                   type: 'layout.set_is_transfer_panel_visible',
                   payload: false
                 })
+                setTransferring(false)
               }
             }
           })
@@ -502,6 +507,7 @@ export function TransferPanel() {
                   type: 'layout.set_is_transfer_panel_visible',
                   payload: false
                 })
+                setTransferring(false)
               }
             }
           })
@@ -517,6 +523,7 @@ export function TransferPanel() {
                   type: 'layout.set_is_transfer_panel_visible',
                   payload: false
                 })
+                setTransferring(false)
               }
             }
           })
@@ -525,7 +532,7 @@ export function TransferPanel() {
     } catch (ex) {
       console.log(ex)
     } finally {
-      dispatch({ type: 'layout.set_is_transferring', payload: false })
+      setTransferring(false)
     }
   }
 

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -31,7 +31,7 @@ import { WithdrawalConfirmationDialog } from './WithdrawalConfirmationDialog'
 import { DepositConfirmationDialog } from './DepositConfirmationDialog'
 import { LowBalanceDialog } from './LowBalanceDialog'
 import { TransferPanelSummary, useGasSummary } from './TransferPanelSummary'
-import { useAppContextDispatch } from '../App/AppContext'
+import { useAppContextDispatch, useAppContextState } from '../App/AppContext'
 import { trackEvent } from '../../util/AnalyticsUtils'
 import {
   TransferPanelMain,
@@ -99,6 +99,8 @@ export function TransferPanel() {
       warningTokens
     }
   } = useAppState()
+  const { layout } = useAppContextState()
+  const { isTransferring } = layout
   const { provider, account } = useWallet()
   const latestConnectedProvider = useLatest(provider)
 
@@ -115,8 +117,6 @@ export function TransferPanel() {
 
   const latestEth = useLatest(eth)
   const latestToken = useLatest(token)
-
-  const [transferring, setTransferring] = useState(false)
 
   const isSwitchingL2Chain = useIsSwitchingL2Chain()
 
@@ -292,7 +292,7 @@ export function TransferPanel() {
     const dialogType = getDialogType()
 
     if (dialogType) {
-      setTokenDepositCheckDialogType(dialogType)
+      if (!isTransferring) setTokenDepositCheckDialogType(dialogType)
 
       const waitForInput = openTokenCheckDialog()
       const confirmed = await waitForInput()
@@ -313,7 +313,7 @@ export function TransferPanel() {
       return
     }
 
-    setTransferring(true)
+    dispatch({ type: 'layout.set_is_transferring', payload: true })
 
     try {
       if (isDepositMode) {
@@ -525,7 +525,7 @@ export function TransferPanel() {
     } catch (ex) {
       console.log(ex)
     } finally {
-      setTransferring(false)
+      dispatch({ type: 'layout.set_is_transferring', payload: false })
     }
   }
 
@@ -621,7 +621,7 @@ export function TransferPanel() {
     }
 
     return (
-      transferring ||
+      isTransferring ||
       !amountNum ||
       (isDepositMode &&
         !isBridgingANewStandardToken &&
@@ -632,7 +632,7 @@ export function TransferPanel() {
         (l1Balance === null || amountNum > +l1Balance))
     )
   }, [
-    transferring,
+    isTransferring,
     isDepositMode,
     l2Network,
     amountNum,
@@ -667,10 +667,10 @@ export function TransferPanel() {
         selectedToken.address &&
         selectedToken.address.toLowerCase() ===
           '0x488cc08935458403a0458e45E20c0159c8AB2c92'.toLowerCase()) ||
-      transferring ||
+      isTransferring ||
       (!isDepositMode && (!amountNum || !l2Balance || amountNum > +l2Balance))
     )
-  }, [transferring, isDepositMode, amountNum, l2Balance, selectedToken])
+  }, [isTransferring, isDepositMode, amountNum, l2Balance, selectedToken])
 
   // TODO: Refactor this and the property above
   const disableWithdrawalV2 = useMemo(() => {
@@ -700,7 +700,7 @@ export function TransferPanel() {
       return false
     }
 
-    if (transferring) {
+    if (isTransferring) {
       return true
     }
 
@@ -708,7 +708,7 @@ export function TransferPanel() {
   }, [
     isSwitchingL2Chain,
     gasEstimationStatus,
-    transferring,
+    isTransferring,
     isDepositMode,
     disableDeposit,
     disableWithdrawal
@@ -781,7 +781,7 @@ export function TransferPanel() {
           {isDepositMode ? (
             <Button
               variant="primary"
-              loading={transferring}
+              loading={isTransferring}
               disabled={isSwitchingL2Chain || disableDepositV2}
               onClick={() => {
                 if (selectedToken) {
@@ -800,7 +800,7 @@ export function TransferPanel() {
           ) : (
             <Button
               variant="primary"
-              loading={transferring}
+              loading={isTransferring}
               disabled={isSwitchingL2Chain || disableWithdrawalV2}
               onClick={transfer}
               className="w-full bg-purple-ethereum py-4 text-lg lg:text-2xl"

--- a/packages/arb-token-bridge-ui/src/components/common/SafeImage.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SafeImage.tsx
@@ -11,7 +11,6 @@ export function SafeImage(props: SafeImageProps) {
   const [validImageSrc, setValidImageSrc] = useState<false | string>(false)
 
   useEffect(() => {
-    let isMounted = true
     const image = new Image()
 
     if (typeof src === 'undefined') {
@@ -19,15 +18,14 @@ export function SafeImage(props: SafeImageProps) {
     } else {
       const sanitizedImageSrc = sanitizeImageSrc(src)
 
-      if (isMounted) {
-        image.onerror = () => setValidImageSrc(false)
-        image.onload = () => setValidImageSrc(sanitizedImageSrc)
-        image.src = sanitizedImageSrc
-      }
+      image.onerror = () => setValidImageSrc(false)
+      image.onload = () => setValidImageSrc(sanitizedImageSrc)
+      image.src = sanitizedImageSrc
     }
 
-    return () => {
-      isMounted = false
+    return function cleanup() {
+      // Abort previous loading
+      image.src = ''
     }
   }, [src])
 

--- a/packages/arb-token-bridge-ui/src/components/common/SafeImage.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SafeImage.tsx
@@ -11,6 +11,7 @@ export function SafeImage(props: SafeImageProps) {
   const [validImageSrc, setValidImageSrc] = useState<false | string>(false)
 
   useEffect(() => {
+    let isMounted = true
     const image = new Image()
 
     if (typeof src === 'undefined') {
@@ -18,14 +19,15 @@ export function SafeImage(props: SafeImageProps) {
     } else {
       const sanitizedImageSrc = sanitizeImageSrc(src)
 
-      image.onerror = () => setValidImageSrc(false)
-      image.onload = () => setValidImageSrc(sanitizedImageSrc)
-      image.src = sanitizedImageSrc
+      if (isMounted) {
+        image.onerror = () => setValidImageSrc(false)
+        image.onload = () => setValidImageSrc(sanitizedImageSrc)
+        image.src = sanitizedImageSrc
+      }
     }
 
-    return function cleanup() {
-      // Abort previous loading
-      image.src = ''
+    return () => {
+      isMounted = false
     }
   }, [src])
 


### PR DESCRIPTION
React would throw errors (updating state of an unmounted component).

TransferPanel: in try catch block, `finally` would get executed after the panel unmounts following transfer initialization. Solution: move setTransferring to layout context.