### PR TITLE
feat: add dropdown icons to navbar

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/Header.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Header.tsx
@@ -219,7 +219,7 @@ export function Header() {
           <a href="/" className="arb-hover flex flex-col items-center">
             <HeaderImageElement src={HeaderArbitrumLogoMainnet} />
           </a>
-          <div className="hidden items-center lg:flex lg:space-x-2 xl:space-x-8">
+          <div className="hidden items-center lg:flex lg:space-x-2 xl:space-x-6">
             <HeaderMenuDesktop {...learnMenuProps}>Learn</HeaderMenuDesktop>
             <HeaderMenuDesktop
               items={[

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderAccountPopover.tsx
@@ -2,7 +2,11 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useCopyToClipboard } from 'react-use'
 import { useWallet } from '@arbitrum/use-wallet'
 import { Popover, Tab } from '@headlessui/react'
-import { ExternalLinkIcon, LogoutIcon } from '@heroicons/react/outline'
+import {
+  ChevronDownIcon,
+  ExternalLinkIcon,
+  LogoutIcon
+} from '@heroicons/react/outline'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Resolution } from '@unstoppabledomains/resolution'
 import BoringAvatar from 'boring-avatars'
@@ -195,6 +199,8 @@ export function HeaderAccountPopover() {
             <span className="text-2xl font-medium text-white lg:text-base lg:font-normal">
               {ensInfo.name ?? udInfo.name ?? accountShort}
             </span>
+
+            <ChevronDownIcon className="h-4 w-4 text-white" />
           </div>
         </div>
       </Popover.Button>

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
@@ -99,7 +99,7 @@ export function HeaderMenuMobile(
             </span>
 
             {props.items?.length && (
-              <ChevronDownIcon className="ml-1 h-4 w-4 shrink-0 grow-0 text-white" />
+              <ChevronDownIcon className="ml-2 h-4 w-4 shrink-0 grow-0 text-white" />
             )}
           </Disclosure.Button>
           <Disclosure.Panel>

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
@@ -86,7 +86,9 @@ export function HeaderMenuMobile(
       {({ open }) => (
         <div className="w-full">
           <Disclosure.Button
-            className={`arb-hover w-full py-3 ${open && `bg-white`}`}
+            className={`arb-hover flex w-full items-center justify-center py-3 ${
+              open && `bg-white`
+            }`}
           >
             <span
               className={`text-2xl font-medium text-white ${
@@ -95,6 +97,10 @@ export function HeaderMenuMobile(
             >
               {props.children}
             </span>
+
+            {props.items?.length && (
+              <ChevronDownIcon className="ml-1 h-4 w-4 shrink-0 grow-0 text-gray-9" />
+            )}
           </Disclosure.Button>
           <Disclosure.Panel>
             <ul className="space-y-4 pt-4 pb-8">

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
@@ -25,7 +25,7 @@ export function HeaderMenuDesktop(
           {props.children}
 
           {props.items?.length && (
-            <ChevronDownIcon className="ml-1 h-4 w-4 shrink-0 grow-0 text-gray-9" />
+            <ChevronDownIcon className="ml-1 h-4 w-4 shrink-0 grow-0 text-white" />
           )}
         </Popover.Button>
       </div>
@@ -99,7 +99,7 @@ export function HeaderMenuMobile(
             </span>
 
             {props.items?.length && (
-              <ChevronDownIcon className="ml-1 h-4 w-4 shrink-0 grow-0 text-gray-9" />
+              <ChevronDownIcon className="ml-1 h-4 w-4 shrink-0 grow-0 text-white" />
             )}
           </Disclosure.Button>
           <Disclosure.Panel>

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderMenu.tsx
@@ -3,6 +3,7 @@ import { Disclosure, Popover } from '@headlessui/react'
 
 import { Transition } from './Transition'
 import { ExternalLink } from './ExternalLink'
+import { ChevronDownIcon } from '@heroicons/react/outline'
 
 export type HeaderMenuItem = {
   title: string
@@ -20,8 +21,12 @@ export function HeaderMenuDesktop(
   return (
     <Popover as="div" className="relative inline-block text-left">
       <div>
-        <Popover.Button className="arb-hover hidden rounded-md text-base text-white lg:inline-flex">
+        <Popover.Button className="arb-hover hidden items-center rounded-md text-base text-white lg:inline-flex lg:p-1">
           {props.children}
+
+          {props.items?.length && (
+            <ChevronDownIcon className="ml-1 h-4 w-4 shrink-0 grow-0 text-gray-9" />
+          )}
         </Popover.Button>
       </div>
 


### PR DESCRIPTION
- [x] Added chevron (dropdown-icons) to nested list items in nav-bar that opens a popover.
- [x] Added a chevron in the profile-icon that opens a popover in navbar
- [x] Excluded similar changes in Network selection header since they are a part of another PR
- [x] Mobile responsive

<p float="left">
<img height="200px" src="https://user-images.githubusercontent.com/7558499/197988218-d86763a8-87ed-45c4-b1ef-e22d7866ad64.png" />
<img height="200px" src="https://user-images.githubusercontent.com/7558499/197989141-cd5d2beb-0e13-41e9-9b9b-d2eed9d73918.png" />
<img height="200px" src="https://user-images.githubusercontent.com/7558499/197989272-508a3d5e-9621-487f-9b57-7eeddcff1cf8.png" />

</p>