### PR TITLE
fix: react warnings

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenButton.tsx
@@ -41,7 +41,7 @@ export function TokenButton(): JSX.Element {
       return sanitizeImageSrc(logo)
     }
     return undefined
-  }, [selectedToken?.address, status, arbTokenBridgeLoaded])
+  }, [bridgeTokens, selectedToken?.address, status, arbTokenBridgeLoaded])
 
   function closeWithReset() {
     setTokenToImport(undefined)

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -349,7 +349,7 @@ export function TransferPanelMain({
 
     // Keep the connected L2 chain id in search params, so it takes preference in any L1 => L2 actions
     setQueryParams({ l2ChainId })
-  }, [isConnectedToArbitrum, externalFrom, externalTo, history])
+  }, [isConnectedToArbitrum, externalFrom, externalTo, history, setQueryParams])
 
   // whenever the user changes the `amount` input, it should update the amount in browser query params as well
   useEffect(() => {

--- a/packages/arb-token-bridge-ui/src/hooks/useTwitter.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTwitter.ts
@@ -12,7 +12,7 @@ const useTwitter = () => {
       .split(' ')
       .join('%20')
   const handleClick = () => {
-    window.open('https://twi' + `tter.com/intent/tweet?text=${text}`)
+    window.open(`https://twitter.com/intent/tweet?text=${text}`)
   }
   return handleClick
 }


### PR DESCRIPTION
These are only a few deps that were added that didn't impact performance: tested the transfer panel and amount input field.

There are more such as `actions.app` which I'm unsure about since it could cause unnecessary loops. Also `dispatch` doesn't have to be added to deps and the warning will be gone should we update to React 18 at some point.

I may add a couple more once we see those not to cause any issues.

Would be nice for a reviewer to test this manually as well to make sure it runs smoothly on other machines still.