### PR TITLE
chore: remove redundant tailwind build

### DIFF
--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -39,9 +39,6 @@
   },
   "scripts": {
     "analyze": "cross-env REACT_APP_INTERACTIVE_ANALYZE=1 $npm_execpath run build",
-    "build:tailwind": "tailwindcss build src/styles/tailwind.css -o src/styles/tailwind.output.css",
-    "prestart": "$npm_execpath run build:tailwind",
-    "prebuild": "$npm_execpath run build:tailwind",
     "start": "craco start",
     "build": "CI= craco build",
     "test": "craco test",


### PR DESCRIPTION
There's no need to run these commands as the TailwindCSS plugin is included in the Webpack config and this line is enough:

https://github.com/OffchainLabs/arb-token-bridge/blob/5c0c634d301f8639a5c258f441c9aceae82736b7/packages/arb-token-bridge-ui/src/index.tsx#L16