### PR TITLE
test: update tests for withdrawals to point to arbitrum one

### DIFF
--- a/packages/token-bridge-sdk/src/common.ts
+++ b/packages/token-bridge-sdk/src/common.ts
@@ -1,5 +1,0 @@
-export const L2_PROVIDER_URL = 'https://arb1.arbitrum.io/rpc'
-export const L2_ACCOUNT_ADDRESS_ETH =
-  '0x09e9222e96e7b4ae2a407b98d48e330053351eee'
-export const L2_ACCOUNT_ADDRESS_ERC20 =
-  '0xb88690461ddbab6f04dfad7df66b7725942feb9c'

--- a/packages/token-bridge-sdk/src/common.ts
+++ b/packages/token-bridge-sdk/src/common.ts
@@ -1,0 +1,5 @@
+export const L2_PROVIDER_URL = 'https://arb1.arbitrum.io/rpc'
+export const L2_ACCOUNT_ADDRESS_ETH =
+  '0x09e9222e96e7b4ae2a407b98d48e330053351eee'
+export const L2_ACCOUNT_ADDRESS_ERC20 =
+  '0xb88690461ddbab6f04dfad7df66b7725942feb9c'

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
@@ -1,32 +1,23 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
-
+import {
+  getQueryCoveringClassicOnlyWithoutResults,
+  getQueryCoveringClassicOnlyWithResults,
+  getQueryCoveringClassicAndNitroWithResults
+} from './fetchETHWithdrawalsTestHelpers'
 import { fetchETHWithdrawalsFromEventLogs } from '../fetchETHWithdrawalsFromEventLogs'
-
-const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
-
-const l2UserAddress = '0xd898275e8b9428429155752f89fe0899ce232830'
-
-/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
 
 describe('fetchETHWithdrawalsFromEventLogs', () => {
   it('fetches no ETH withdrawals from event logs pre-nitro', async () => {
-    const result = await fetchETHWithdrawalsFromEventLogs({
-      address: l2UserAddress,
-      fromBlock: 0,
-      toBlock: 20785771,
-      l2Provider
-    })
+    const result = await fetchETHWithdrawalsFromEventLogs(
+      getQueryCoveringClassicOnlyWithoutResults()
+    )
 
     expect(result).toHaveLength(0)
   })
 
   it('fetches some ETH withdrawals from event logs pre-nitro', async () => {
-    const result = await fetchETHWithdrawalsFromEventLogs({
-      address: l2UserAddress,
-      fromBlock: 20785772,
-      toBlock: 22964111,
-      l2Provider
-    })
+    const result = await fetchETHWithdrawalsFromEventLogs(
+      getQueryCoveringClassicOnlyWithResults()
+    )
 
     expect(result).toHaveLength(1)
     expect(result).toEqual(
@@ -40,12 +31,9 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
   })
 
   it('fetches some ETH withdrawals from event logs pre-nitro and post-nitro', async () => {
-    const result = await fetchETHWithdrawalsFromEventLogs({
-      address: l2UserAddress,
-      fromBlock: 20785772,
-      toBlock: 24905369,
-      l2Provider
-    })
+    const result = await fetchETHWithdrawalsFromEventLogs(
+      getQueryCoveringClassicAndNitroWithResults()
+    )
 
     expect(result).toHaveLength(3)
     expect(result).toEqual(

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
@@ -4,10 +4,14 @@ import { fetchETHWithdrawalsFromEventLogs } from '../fetchETHWithdrawalsFromEven
 
 const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
+const l2UserAddress = '0xd898275e8b9428429155752f89fe0899ce232830'
+
+/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
+
 describe('fetchETHWithdrawalsFromEventLogs', () => {
   it('fetches no ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      address: l2UserAddress,
       fromBlock: 0,
       toBlock: 20785771,
       l2Provider
@@ -18,7 +22,7 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
 
   it('fetches some ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      address: l2UserAddress,
       fromBlock: 20785772,
       toBlock: 22964111,
       l2Provider
@@ -37,15 +41,19 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
 
   it('fetches some ETH withdrawals from event logs pre-nitro and post-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: '0xd898275e8b9428429155752f89fe0899ce232830',
-      fromBlock: 22964112,
+      address: l2UserAddress,
+      fromBlock: 20785772,
       toBlock: 24905369,
       l2Provider
     })
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(3)
     expect(result).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          transactionHash:
+            '0x7378773d1af4cfbbc91179efdaf63872f8e1cb7f84e9a9511ef3f1ce6dbcb671'
+        }),
         expect.objectContaining({
           transactionHash:
             '0xf9e53f80b90b95b940573d1a2b76d2fe240a4fe6e96272771553400d4cb17fd0'

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
@@ -1,16 +1,15 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { L2_PROVIDER_URL, L2_ACCOUNT_ADDRESS_ETH } from '../../common'
 
 import { fetchETHWithdrawalsFromEventLogs } from '../fetchETHWithdrawalsFromEventLogs'
 
-const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
+const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
 describe('fetchETHWithdrawalsFromEventLogs', () => {
   it('fetches no ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: L2_ACCOUNT_ADDRESS_ETH,
+      address: '0xd898275e8b9428429155752f89fe0899ce232830',
       fromBlock: 0,
-      toBlock: 2136,
+      toBlock: 20785771,
       l2Provider
     })
 
@@ -19,26 +18,18 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
 
   it('fetches some ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: L2_ACCOUNT_ADDRESS_ETH,
-      fromBlock: 2136,
-      toBlock: 224417,
+      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      fromBlock: 20785772,
+      toBlock: 22964111,
       l2Provider
     })
 
-    expect(result).toHaveLength(3)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           transactionHash:
-            '0x5b52bed323fab12d6eafcf4a7f2a67efb78f20b970332aba8967602c33a6f505'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0xe49110aa248f0cdcf977bd78dabbd3d50a81c21195a62ee9a3287bdc7bfe4977'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0x96c9e940a9177e4c9a7bbe91ba18983df5c73c542c541cffd6d1a738c3ce52fe'
+            '0x7378773d1af4cfbbc91179efdaf63872f8e1cb7f84e9a9511ef3f1ce6dbcb671'
         })
       ])
     )
@@ -46,9 +37,9 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
 
   it('fetches some ETH withdrawals from event logs pre-nitro and post-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: L2_ACCOUNT_ADDRESS_ETH,
-      fromBlock: 22204081,
-      toBlock: 22216295,
+      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      fromBlock: 22964112,
+      toBlock: 24905369,
       l2Provider
     })
 
@@ -57,11 +48,11 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
       expect.arrayContaining([
         expect.objectContaining({
           transactionHash:
-            '0xe18871590da25b062f774d841423dcdbcd54d8879b9f8851e3fffb92c655c52b'
+            '0xf9e53f80b90b95b940573d1a2b76d2fe240a4fe6e96272771553400d4cb17fd0'
         }),
         expect.objectContaining({
           transactionHash:
-            '0xf4a0ef245233a669b0460e4134db4452b89a7d5f06815e3469b441ad4f5d0e19'
+            '0x021973feaad7c7813ac06a4d4cfac32455fbdf9e13cf427edcebd1bf4e5f12cf'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromEventLogs.test.ts
@@ -1,15 +1,16 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
+import { L2_PROVIDER_URL, L2_ACCOUNT_ADDRESS_ETH } from '../../common'
 
 import { fetchETHWithdrawalsFromEventLogs } from '../fetchETHWithdrawalsFromEventLogs'
 
-const l2Provider = new JsonRpcProvider('https://rinkeby.arbitrum.io/rpc')
+const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
 
 describe('fetchETHWithdrawalsFromEventLogs', () => {
   it('fetches no ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
+      address: L2_ACCOUNT_ADDRESS_ETH,
       fromBlock: 0,
-      toBlock: 11110000,
+      toBlock: 2136,
       l2Provider
     })
 
@@ -18,34 +19,26 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
 
   it('fetches some ETH withdrawals from event logs pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 11110000,
-      toBlock: 12055296,
+      address: L2_ACCOUNT_ADDRESS_ETH,
+      fromBlock: 2136,
+      toBlock: 224417,
       l2Provider
     })
 
-    expect(result).toHaveLength(5)
+    expect(result).toHaveLength(3)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           transactionHash:
-            '0xdc8f593a5c19f2133e59c6e332dee0f330d977ffa11387eee2cfc55cee1722e7'
+            '0x5b52bed323fab12d6eafcf4a7f2a67efb78f20b970332aba8967602c33a6f505'
         }),
         expect.objectContaining({
           transactionHash:
-            '0xb482555a63edc154035834a7380ae3787c0126730228d4e1dce97520f25ed0f7'
+            '0xe49110aa248f0cdcf977bd78dabbd3d50a81c21195a62ee9a3287bdc7bfe4977'
         }),
         expect.objectContaining({
           transactionHash:
-            '0xa639f70688a095ce3134c4768de5ef0e2fbad804ca4bdee8dc56131b4500bcb9'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0xc3636c940f800ccc14e83a35448cc62ab9c5bd9bcdb25cc451769df9bd0260e0'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0x821b91067d86d4081639183e29d00f1e553370f979514337f1aa2b867250a269'
+            '0x96c9e940a9177e4c9a7bbe91ba18983df5c73c542c541cffd6d1a738c3ce52fe'
         })
       ])
     )
@@ -53,34 +46,22 @@ describe('fetchETHWithdrawalsFromEventLogs', () => {
 
   it('fetches some ETH withdrawals from event logs pre-nitro and post-nitro', async () => {
     const result = await fetchETHWithdrawalsFromEventLogs({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 13744993,
-      toBlock: 13956985,
+      address: L2_ACCOUNT_ADDRESS_ETH,
+      fromBlock: 22204081,
+      toBlock: 22216295,
       l2Provider
     })
 
-    expect(result).toHaveLength(5)
+    expect(result).toHaveLength(2)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           transactionHash:
-            '0x72ba5c0babbdea27a4b405b041b307b8a9bd420ec8f716071136b51fc660ad2c'
+            '0xe18871590da25b062f774d841423dcdbcd54d8879b9f8851e3fffb92c655c52b'
         }),
         expect.objectContaining({
           transactionHash:
-            '0x9dcdafe1f4cc1b5cf3b568ed3a4b6529dcbde5c71dbe2b6ded624e3b78056b76'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0xa0f9390177977fc0abf839c36808e853e1213e7583b48d2d48341fa41d054732'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0xbeba9bc68ad640f6b946d3cd157dd51b3f272072c6a31234e5706e00c1bdb40b'
-        }),
-        expect.objectContaining({
-          transactionHash:
-            '0x050fed85e2b48d4937663a9597d60a97929150072e3e9403b1f07dbdf080a9af'
+            '0xf4a0ef245233a669b0460e4134db4452b89a7d5f06815e3469b441ad4f5d0e19'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
@@ -1,16 +1,15 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { L2_PROVIDER_URL, L2_ACCOUNT_ADDRESS_ETH } from '../../common'
 
 import { fetchETHWithdrawalsFromSubgraph } from '../fetchETHWithdrawalsFromSubgraph'
 
-const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
+const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
 describe('fetchETHWithdrawalsFromSubgraph', () => {
   it('fetches no ETH withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: L2_ACCOUNT_ADDRESS_ETH,
+      address: '0xd898275e8b9428429155752f89fe0899ce232830',
       fromBlock: 0,
-      toBlock: 2136,
+      toBlock: 20785771,
       l2Provider
     })
 
@@ -19,26 +18,18 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
 
   it('fetches some ETH withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: L2_ACCOUNT_ADDRESS_ETH,
-      fromBlock: 2136,
-      toBlock: 224417,
+      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      fromBlock: 20785772,
+      toBlock: 22964111,
       l2Provider
     })
 
-    expect(result).toHaveLength(3)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0x5b52bed323fab12d6eafcf4a7f2a67efb78f20b970332aba8967602c33a6f505'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0xe49110aa248f0cdcf977bd78dabbd3d50a81c21195a62ee9a3287bdc7bfe4977'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0x96c9e940a9177e4c9a7bbe91ba18983df5c73c542c541cffd6d1a738c3ce52fe'
+            '0x7378773d1af4cfbbc91179efdaf63872f8e1cb7f84e9a9511ef3f1ce6dbcb671'
         })
       ])
     )
@@ -46,9 +37,9 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
 
   it('fetches some ETH withdrawals from subgraph pre-nitro and post-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: L2_ACCOUNT_ADDRESS_ETH,
-      fromBlock: 22204081,
-      toBlock: 22216295,
+      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      fromBlock: 22964112,
+      toBlock: 24905369,
       l2Provider
     })
 
@@ -57,11 +48,11 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0xe18871590da25b062f774d841423dcdbcd54d8879b9f8851e3fffb92c655c52b'
+            '0xf9e53f80b90b95b940573d1a2b76d2fe240a4fe6e96272771553400d4cb17fd0'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xf4a0ef245233a669b0460e4134db4452b89a7d5f06815e3469b441ad4f5d0e19'
+            '0x021973feaad7c7813ac06a4d4cfac32455fbdf9e13cf427edcebd1bf4e5f12cf'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
@@ -4,10 +4,14 @@ import { fetchETHWithdrawalsFromSubgraph } from '../fetchETHWithdrawalsFromSubgr
 
 const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
+const l2UserAddress = '0xd898275e8b9428429155752f89fe0899ce232830'
+
+/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
+
 describe('fetchETHWithdrawalsFromSubgraph', () => {
   it('fetches no ETH withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      address: l2UserAddress,
       fromBlock: 0,
       toBlock: 20785771,
       l2Provider
@@ -18,7 +22,7 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
 
   it('fetches some ETH withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: '0xd898275e8b9428429155752f89fe0899ce232830',
+      address: l2UserAddress,
       fromBlock: 20785772,
       toBlock: 22964111,
       l2Provider
@@ -37,15 +41,19 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
 
   it('fetches some ETH withdrawals from subgraph pre-nitro and post-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: '0xd898275e8b9428429155752f89fe0899ce232830',
-      fromBlock: 22964112,
+      address: l2UserAddress,
+      fromBlock: 20785772,
       toBlock: 24905369,
       l2Provider
     })
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(3)
     expect(result).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          l2TxHash:
+            '0x7378773d1af4cfbbc91179efdaf63872f8e1cb7f84e9a9511ef3f1ce6dbcb671'
+        }),
         expect.objectContaining({
           l2TxHash:
             '0xf9e53f80b90b95b940573d1a2b76d2fe240a4fe6e96272771553400d4cb17fd0'

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
@@ -1,32 +1,23 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
-
+import {
+  getQueryCoveringClassicOnlyWithoutResults,
+  getQueryCoveringClassicOnlyWithResults,
+  getQueryCoveringClassicAndNitroWithResults
+} from './fetchETHWithdrawalsTestHelpers'
 import { fetchETHWithdrawalsFromSubgraph } from '../fetchETHWithdrawalsFromSubgraph'
-
-const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
-
-const l2UserAddress = '0xd898275e8b9428429155752f89fe0899ce232830'
-
-/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
 
 describe('fetchETHWithdrawalsFromSubgraph', () => {
   it('fetches no ETH withdrawals from subgraph pre-nitro', async () => {
-    const result = await fetchETHWithdrawalsFromSubgraph({
-      address: l2UserAddress,
-      fromBlock: 0,
-      toBlock: 20785771,
-      l2Provider
-    })
+    const result = await fetchETHWithdrawalsFromSubgraph(
+      getQueryCoveringClassicOnlyWithoutResults()
+    )
 
     expect(result).toHaveLength(0)
   })
 
   it('fetches some ETH withdrawals from subgraph pre-nitro', async () => {
-    const result = await fetchETHWithdrawalsFromSubgraph({
-      address: l2UserAddress,
-      fromBlock: 20785772,
-      toBlock: 22964111,
-      l2Provider
-    })
+    const result = await fetchETHWithdrawalsFromSubgraph(
+      getQueryCoveringClassicOnlyWithResults()
+    )
 
     expect(result).toHaveLength(1)
     expect(result).toEqual(
@@ -40,12 +31,9 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
   })
 
   it('fetches some ETH withdrawals from subgraph pre-nitro and post-nitro', async () => {
-    const result = await fetchETHWithdrawalsFromSubgraph({
-      address: l2UserAddress,
-      fromBlock: 20785772,
-      toBlock: 24905369,
-      l2Provider
-    })
+    const result = await fetchETHWithdrawalsFromSubgraph(
+      getQueryCoveringClassicAndNitroWithResults()
+    )
 
     expect(result).toHaveLength(3)
     expect(result).toEqual(

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsFromSubgraph.test.ts
@@ -1,15 +1,16 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
+import { L2_PROVIDER_URL, L2_ACCOUNT_ADDRESS_ETH } from '../../common'
 
 import { fetchETHWithdrawalsFromSubgraph } from '../fetchETHWithdrawalsFromSubgraph'
 
-const l2Provider = new JsonRpcProvider('https://rinkeby.arbitrum.io/rpc')
+const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
 
 describe('fetchETHWithdrawalsFromSubgraph', () => {
   it('fetches no ETH withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
+      address: L2_ACCOUNT_ADDRESS_ETH,
       fromBlock: 0,
-      toBlock: 11110000,
+      toBlock: 2136,
       l2Provider
     })
 
@@ -18,34 +19,26 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
 
   it('fetches some ETH withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 11110000,
-      toBlock: 12055296,
+      address: L2_ACCOUNT_ADDRESS_ETH,
+      fromBlock: 2136,
+      toBlock: 224417,
       l2Provider
     })
 
-    expect(result).toHaveLength(5)
+    expect(result).toHaveLength(3)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0xdc8f593a5c19f2133e59c6e332dee0f330d977ffa11387eee2cfc55cee1722e7'
+            '0x5b52bed323fab12d6eafcf4a7f2a67efb78f20b970332aba8967602c33a6f505'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xb482555a63edc154035834a7380ae3787c0126730228d4e1dce97520f25ed0f7'
+            '0xe49110aa248f0cdcf977bd78dabbd3d50a81c21195a62ee9a3287bdc7bfe4977'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xa639f70688a095ce3134c4768de5ef0e2fbad804ca4bdee8dc56131b4500bcb9'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0xc3636c940f800ccc14e83a35448cc62ab9c5bd9bcdb25cc451769df9bd0260e0'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0x821b91067d86d4081639183e29d00f1e553370f979514337f1aa2b867250a269'
+            '0x96c9e940a9177e4c9a7bbe91ba18983df5c73c542c541cffd6d1a738c3ce52fe'
         })
       ])
     )
@@ -53,34 +46,22 @@ describe('fetchETHWithdrawalsFromSubgraph', () => {
 
   it('fetches some ETH withdrawals from subgraph pre-nitro and post-nitro', async () => {
     const result = await fetchETHWithdrawalsFromSubgraph({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 13744993,
-      toBlock: 13956985,
+      address: L2_ACCOUNT_ADDRESS_ETH,
+      fromBlock: 22204081,
+      toBlock: 22216295,
       l2Provider
     })
 
-    expect(result).toHaveLength(5)
+    expect(result).toHaveLength(2)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0x72ba5c0babbdea27a4b405b041b307b8a9bd420ec8f716071136b51fc660ad2c'
+            '0xe18871590da25b062f774d841423dcdbcd54d8879b9f8851e3fffb92c655c52b'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0x9dcdafe1f4cc1b5cf3b568ed3a4b6529dcbde5c71dbe2b6ded624e3b78056b76'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0xa0f9390177977fc0abf839c36808e853e1213e7583b48d2d48341fa41d054732'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0xbeba9bc68ad640f6b946d3cd157dd51b3f272072c6a31234e5706e00c1bdb40b'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0x050fed85e2b48d4937663a9597d60a97929150072e3e9403b1f07dbdf080a9af'
+            '0xf4a0ef245233a669b0460e4134db4452b89a7d5f06815e3469b441ad4f5d0e19'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsTestHelpers.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsTestHelpers.ts
@@ -1,0 +1,21 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
+
+const address = '0xd898275e8b9428429155752f89fe0899ce232830'
+const l2Provider = new StaticJsonRpcProvider('https://arb1.arbitrum.io/rpc')
+
+const baseQuery = {
+  address,
+  l2Provider
+}
+
+export function getQueryCoveringClassicOnlyWithoutResults() {
+  return { ...baseQuery, fromBlock: 0, toBlock: 20785771 }
+}
+
+export function getQueryCoveringClassicOnlyWithResults() {
+  return { ...baseQuery, fromBlock: 20785772, toBlock: 22964111 }
+}
+
+export function getQueryCoveringClassicAndNitroWithResults() {
+  return { ...baseQuery, fromBlock: 20785772, toBlock: 24905369 }
+}

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsTestHelpers.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsTestHelpers.ts
@@ -13,7 +13,7 @@ export function getQueryCoveringClassicOnlyWithoutResults() {
 }
 
 export function getQueryCoveringClassicOnlyWithResults() {
-  return { ...baseQuery, fromBlock: 20785772, toBlock: 22964111 }
+  return { ...baseQuery, fromBlock: 20785772, toBlock: 22207817 }
 }
 
 export function getQueryCoveringClassicAndNitroWithResults() {

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsTestHelpers.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchETHWithdrawalsTestHelpers.ts
@@ -13,7 +13,7 @@ export function getQueryCoveringClassicOnlyWithoutResults() {
 }
 
 export function getQueryCoveringClassicOnlyWithResults() {
-  return { ...baseQuery, fromBlock: 20785772, toBlock: 22207817 }
+  return { ...baseQuery, fromBlock: 20785772, toBlock: 22207816 }
 }
 
 export function getQueryCoveringClassicAndNitroWithResults() {

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
@@ -1,47 +1,23 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
-import { getL2Network, L2Network } from '@arbitrum/sdk'
-
+import {
+  getQueryCoveringClassicOnlyWithoutResults,
+  getQueryCoveringClassicOnlyWithResults,
+  getQueryCoveringClassicAndNitroWithResults
+} from './fetchTokenWithdrawalsTestHelpers'
 import { fetchTokenWithdrawalsFromEventLogs } from '../fetchTokenWithdrawalsFromEventLogs'
-
-const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
-
-const l2UserAddress = '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299'
-
-/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
-
-let l2Network: L2Network
-let l2GatewayAddresses: string[]
-
-beforeAll(async () => {
-  l2Network = await getL2Network(l2Provider)
-
-  const tokenBridge = l2Network.tokenBridge
-  const { l2ERC20Gateway, l2CustomGateway, l2WethGateway } = tokenBridge
-
-  l2GatewayAddresses = [l2ERC20Gateway, l2CustomGateway, l2WethGateway]
-})
 
 describe('fetchTokenWithdrawalsFromEventLogs', () => {
   it('fetches no token withdrawals from event logs pre-nitro', async () => {
-    const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: l2UserAddress,
-      fromBlock: 0,
-      toBlock: 20961063,
-      l2Provider,
-      l2GatewayAddresses
-    })
+    const result = await fetchTokenWithdrawalsFromEventLogs(
+      getQueryCoveringClassicOnlyWithoutResults()
+    )
 
     expect(result).toHaveLength(0)
   })
 
   it('fetches some token withdrawals from event logs pre-nitro', async () => {
-    const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: l2UserAddress,
-      fromBlock: 20961064,
-      toBlock: 26317225,
-      l2Provider,
-      l2GatewayAddresses
-    })
+    const result = await fetchTokenWithdrawalsFromEventLogs(
+      getQueryCoveringClassicOnlyWithResults()
+    )
 
     expect(result).toHaveLength(1)
     expect(result).toEqual(
@@ -55,13 +31,9 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
   })
 
   it('fetches some token withdrawals from event logs pre-nitro and post-nitro', async () => {
-    const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: l2UserAddress,
-      fromBlock: 20961064,
-      toBlock: 35134792,
-      l2Provider,
-      l2GatewayAddresses
-    })
+    const result = await fetchTokenWithdrawalsFromEventLogs(
+      getQueryCoveringClassicAndNitroWithResults()
+    )
 
     expect(result).toHaveLength(5)
     expect(result).toEqual(

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
@@ -2,8 +2,9 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { getL2Network, L2Network } from '@arbitrum/sdk'
 
 import { fetchTokenWithdrawalsFromEventLogs } from '../fetchTokenWithdrawalsFromEventLogs'
+import { L2_ACCOUNT_ADDRESS_ERC20, L2_PROVIDER_URL } from '../../common'
 
-const l2Provider = new JsonRpcProvider('https://rinkeby.arbitrum.io/rpc')
+const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
 
 let l2Network: L2Network
 let l2GatewayAddresses: string[]
@@ -20,9 +21,9 @@ beforeAll(async () => {
 describe('fetchTokenWithdrawalsFromEventLogs', () => {
   it('fetches no token withdrawals from event logs pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
+      address: L2_ACCOUNT_ADDRESS_ERC20,
       fromBlock: 0,
-      toBlock: 11110000,
+      toBlock: 12880678,
       l2Provider,
       l2GatewayAddresses
     })
@@ -32,27 +33,27 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
 
   it('fetches some token withdrawals from event logs pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 11110000,
-      toBlock: 12055296,
+      address: L2_ACCOUNT_ADDRESS_ERC20,
+      fromBlock: 12880679,
+      toBlock: 12889471,
       l2Provider,
       l2GatewayAddresses
     })
 
-    expect(result).toHaveLength(3)
+    expect(result).toHaveLength(4)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           txHash:
-            '0xd747141d1bff3c9eb6c11c9bb39a0152de70267449dffe28eafd53f1989566a6'
+            '0xa2a31cb4aa747889245b368c93cdb0ccfa1b8e14e907763080b43112ef1dcc4e'
         }),
         expect.objectContaining({
           txHash:
-            '0x417c9d1928947f5e96b35be3843bcd1eeeacaa64a781aa5b9089a9b255f30107'
+            '0x815973ff35fcd84c54b8651a0c9a36d8c1ddf1bc64b18d673443c918283823c3'
         }),
         expect.objectContaining({
           txHash:
-            '0xcce63179f64478c81bb4d915208369a85fa5d891bfe56348109035f95fcae898'
+            '0x9444cd8a461963edb380d32cf11b0c6e16c2e917c11d3d81e4324a0081bf99f1'
         })
       ])
     )
@@ -60,23 +61,43 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
 
   it('fetches some token withdrawals from event logs pre-nitro and post-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 13910741,
-      toBlock: 13927058,
+      address: L2_ACCOUNT_ADDRESS_ERC20,
+      fromBlock: 22136283,
+      toBlock: 22231082,
       l2Provider,
       l2GatewayAddresses
     })
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(6)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           txHash:
-            '0x5f64136fe311b9ec42e22ac43360f519a0728954a5f122cb93cf5214d1a113cc'
+            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
         }),
         expect.objectContaining({
           txHash:
-            '0xd9b0a17fc302210a0c084f55f653ab654c72aecbe1a2a2e3edf707c34261217f'
+            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+        }),
+        expect.objectContaining({
+          txHash:
+            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+        }),
+        expect.objectContaining({
+          txHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+        }),
+        expect.objectContaining({
+          txHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+        }),
+        expect.objectContaining({
+          txHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+        }),
+        expect.objectContaining({
+          txHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
@@ -5,6 +5,10 @@ import { fetchTokenWithdrawalsFromEventLogs } from '../fetchTokenWithdrawalsFrom
 
 const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
+const l2UserAddress = '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299'
+
+/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
+
 let l2Network: L2Network
 let l2GatewayAddresses: string[]
 
@@ -20,7 +24,7 @@ beforeAll(async () => {
 describe('fetchTokenWithdrawalsFromEventLogs', () => {
   it('fetches no token withdrawals from event logs pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      address: l2UserAddress,
       fromBlock: 0,
       toBlock: 20961063,
       l2Provider,
@@ -32,7 +36,7 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
 
   it('fetches some token withdrawals from event logs pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      address: l2UserAddress,
       fromBlock: 20961064,
       toBlock: 26317225,
       l2Provider,
@@ -52,7 +56,7 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
 
   it('fetches some token withdrawals from event logs pre-nitro and post-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      address: l2UserAddress,
       fromBlock: 20961064,
       toBlock: 35134792,
       l2Provider,

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromEventLogs.test.ts
@@ -2,9 +2,8 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { getL2Network, L2Network } from '@arbitrum/sdk'
 
 import { fetchTokenWithdrawalsFromEventLogs } from '../fetchTokenWithdrawalsFromEventLogs'
-import { L2_ACCOUNT_ADDRESS_ERC20, L2_PROVIDER_URL } from '../../common'
 
-const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
+const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
 let l2Network: L2Network
 let l2GatewayAddresses: string[]
@@ -21,9 +20,9 @@ beforeAll(async () => {
 describe('fetchTokenWithdrawalsFromEventLogs', () => {
   it('fetches no token withdrawals from event logs pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: L2_ACCOUNT_ADDRESS_ERC20,
+      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
       fromBlock: 0,
-      toBlock: 12880678,
+      toBlock: 20961063,
       l2Provider,
       l2GatewayAddresses
     })
@@ -33,27 +32,19 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
 
   it('fetches some token withdrawals from event logs pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: L2_ACCOUNT_ADDRESS_ERC20,
-      fromBlock: 12880679,
-      toBlock: 12889471,
+      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      fromBlock: 20961064,
+      toBlock: 26317225,
       l2Provider,
       l2GatewayAddresses
     })
 
-    expect(result).toHaveLength(4)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           txHash:
-            '0xa2a31cb4aa747889245b368c93cdb0ccfa1b8e14e907763080b43112ef1dcc4e'
-        }),
-        expect.objectContaining({
-          txHash:
-            '0x815973ff35fcd84c54b8651a0c9a36d8c1ddf1bc64b18d673443c918283823c3'
-        }),
-        expect.objectContaining({
-          txHash:
-            '0x9444cd8a461963edb380d32cf11b0c6e16c2e917c11d3d81e4324a0081bf99f1'
+            '0x98c3c3bf97f177e80ac5a5adb154208e5ad43120455e624fff917a7546273800'
         })
       ])
     )
@@ -61,43 +52,35 @@ describe('fetchTokenWithdrawalsFromEventLogs', () => {
 
   it('fetches some token withdrawals from event logs pre-nitro and post-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromEventLogs({
-      address: L2_ACCOUNT_ADDRESS_ERC20,
-      fromBlock: 22136283,
-      toBlock: 22231082,
+      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      fromBlock: 20961064,
+      toBlock: 35134792,
       l2Provider,
       l2GatewayAddresses
     })
 
-    expect(result).toHaveLength(6)
+    expect(result).toHaveLength(5)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           txHash:
-            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+            '0x98c3c3bf97f177e80ac5a5adb154208e5ad43120455e624fff917a7546273800'
         }),
         expect.objectContaining({
           txHash:
-            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+            '0xcf38b3fe57a4d823d0dd4b4ba3792f51640a4575f7da8fb582e5006bf60bceb3'
         }),
         expect.objectContaining({
           txHash:
-            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+            '0xbd809fa3ad466a5a88628f3f0f9fc92df4ab9d9b1bd6b3861cd87cb464a9a7c3'
         }),
         expect.objectContaining({
           txHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+            '0xbe4141f4b6847ef1f3196734beefa1ac08149abc8beba2d8d71055995cd3c29b'
         }),
         expect.objectContaining({
           txHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
-        }),
-        expect.objectContaining({
-          txHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
-        }),
-        expect.objectContaining({
-          txHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+            '0x420eadd347bda4bfe5d44a96e0ae68347cb181ee7a910198582e9535665cdb38'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
@@ -1,32 +1,23 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
-
+import {
+  getQueryCoveringClassicOnlyWithoutResults,
+  getQueryCoveringClassicOnlyWithResults,
+  getQueryCoveringClassicAndNitroWithResults
+} from './fetchTokenWithdrawalsTestHelpers'
 import { fetchTokenWithdrawalsFromSubgraph } from '../fetchTokenWithdrawalsFromSubgraph'
-
-const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
-
-const l2UserAddress = '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299'
-
-/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
 
 describe('fetchTokenWithdrawalsFromSubgraph', () => {
   it('fetches no token withdrawals from subgraph pre-nitro', async () => {
-    const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: l2UserAddress,
-      fromBlock: 0,
-      toBlock: 20961063,
-      l2Provider
-    })
+    const result = await fetchTokenWithdrawalsFromSubgraph(
+      getQueryCoveringClassicOnlyWithoutResults()
+    )
 
     expect(result).toHaveLength(0)
   })
 
   it('fetches some token withdrawals from subgraph pre-nitro', async () => {
-    const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: l2UserAddress,
-      fromBlock: 20961064,
-      toBlock: 26317225,
-      l2Provider
-    })
+    const result = await fetchTokenWithdrawalsFromSubgraph(
+      getQueryCoveringClassicOnlyWithResults()
+    )
 
     expect(result).toHaveLength(1)
     expect(result).toEqual(
@@ -40,12 +31,9 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
   })
 
   it('fetches some token withdrawals from subgraph pre-nitro and post-nitro', async () => {
-    const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: l2UserAddress,
-      fromBlock: 20961064,
-      toBlock: 35134792,
-      l2Provider
-    })
+    const result = await fetchTokenWithdrawalsFromSubgraph(
+      getQueryCoveringClassicAndNitroWithResults()
+    )
 
     expect(result).toHaveLength(5)
     expect(result).toEqual(

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
@@ -1,18 +1,17 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
-import { L2_ACCOUNT_ADDRESS_ERC20, L2_PROVIDER_URL } from '../../common'
 
 import { fetchTokenWithdrawalsFromSubgraph } from '../fetchTokenWithdrawalsFromSubgraph'
 
-const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
+const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
 jest.setTimeout(10000)
 
 describe('fetchTokenWithdrawalsFromSubgraph', () => {
   it('fetches no token withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: L2_ACCOUNT_ADDRESS_ERC20,
+      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
       fromBlock: 0,
-      toBlock: 12880678,
+      toBlock: 20961063,
       l2Provider
     })
 
@@ -21,30 +20,18 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some token withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: L2_ACCOUNT_ADDRESS_ERC20,
-      fromBlock: 12880679,
-      toBlock: 12889471,
+      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      fromBlock: 20961064,
+      toBlock: 26317225,
       l2Provider
     })
 
-    expect(result).toHaveLength(4)
+    expect(result).toHaveLength(1)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0xa2a31cb4aa747889245b368c93cdb0ccfa1b8e14e907763080b43112ef1dcc4e'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0x815973ff35fcd84c54b8651a0c9a36d8c1ddf1bc64b18d673443c918283823c3'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0x9444cd8a461963edb380d32cf11b0c6e16c2e917c11d3d81e4324a0081bf99f1'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0x9444cd8a461963edb380d32cf11b0c6e16c2e917c11d3d81e4324a0081bf99f1'
+            '0x98c3c3bf97f177e80ac5a5adb154208e5ad43120455e624fff917a7546273800'
         })
       ])
     )
@@ -52,42 +39,34 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some token withdrawals from subgraph pre-nitro and post-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: L2_ACCOUNT_ADDRESS_ERC20,
-      fromBlock: 22136283,
-      toBlock: 22231082,
+      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      fromBlock: 20961064,
+      toBlock: 35134792,
       l2Provider
     })
 
-    expect(result).toHaveLength(7)
+    expect(result).toHaveLength(5)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+            '0x98c3c3bf97f177e80ac5a5adb154208e5ad43120455e624fff917a7546273800'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+            '0xcf38b3fe57a4d823d0dd4b4ba3792f51640a4575f7da8fb582e5006bf60bceb3'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+            '0xbd809fa3ad466a5a88628f3f0f9fc92df4ab9d9b1bd6b3861cd87cb464a9a7c3'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+            '0xbe4141f4b6847ef1f3196734beefa1ac08149abc8beba2d8d71055995cd3c29b'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
-        }),
-        expect.objectContaining({
-          l2TxHash:
-            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+            '0x420eadd347bda4bfe5d44a96e0ae68347cb181ee7a910198582e9535665cdb38'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
@@ -1,15 +1,18 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
+import { L2_ACCOUNT_ADDRESS_ERC20, L2_PROVIDER_URL } from '../../common'
 
 import { fetchTokenWithdrawalsFromSubgraph } from '../fetchTokenWithdrawalsFromSubgraph'
 
-const l2Provider = new JsonRpcProvider('https://rinkeby.arbitrum.io/rpc')
+const l2Provider = new JsonRpcProvider(L2_PROVIDER_URL)
+
+jest.setTimeout(10000)
 
 describe('fetchTokenWithdrawalsFromSubgraph', () => {
   it('fetches no token withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
+      address: L2_ACCOUNT_ADDRESS_ERC20,
       fromBlock: 0,
-      toBlock: 11110000,
+      toBlock: 12880678,
       l2Provider
     })
 
@@ -18,26 +21,30 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some token withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 11110000,
-      toBlock: 12055296,
+      address: L2_ACCOUNT_ADDRESS_ERC20,
+      fromBlock: 12880679,
+      toBlock: 12889471,
       l2Provider
     })
 
-    expect(result).toHaveLength(3)
+    expect(result).toHaveLength(4)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0xd747141d1bff3c9eb6c11c9bb39a0152de70267449dffe28eafd53f1989566a6'
+            '0xa2a31cb4aa747889245b368c93cdb0ccfa1b8e14e907763080b43112ef1dcc4e'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0x417c9d1928947f5e96b35be3843bcd1eeeacaa64a781aa5b9089a9b255f30107'
+            '0x815973ff35fcd84c54b8651a0c9a36d8c1ddf1bc64b18d673443c918283823c3'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xcce63179f64478c81bb4d915208369a85fa5d891bfe56348109035f95fcae898'
+            '0x9444cd8a461963edb380d32cf11b0c6e16c2e917c11d3d81e4324a0081bf99f1'
+        }),
+        expect.objectContaining({
+          l2TxHash:
+            '0x9444cd8a461963edb380d32cf11b0c6e16c2e917c11d3d81e4324a0081bf99f1'
         })
       ])
     )
@@ -45,22 +52,42 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some token withdrawals from subgraph pre-nitro and post-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: '0x41C966f99De0cA6F6531fbcAc9Db7eaBDF119744',
-      fromBlock: 13910741,
-      toBlock: 13927058,
+      address: L2_ACCOUNT_ADDRESS_ERC20,
+      fromBlock: 22136283,
+      toBlock: 22231082,
       l2Provider
     })
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(7)
     expect(result).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           l2TxHash:
-            '0x5f64136fe311b9ec42e22ac43360f519a0728954a5f122cb93cf5214d1a113cc'
+            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
         }),
         expect.objectContaining({
           l2TxHash:
-            '0xd9b0a17fc302210a0c084f55f653ab654c72aecbe1a2a2e3edf707c34261217f'
+            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+        }),
+        expect.objectContaining({
+          l2TxHash:
+            '0xa9a4ff859d3d5e727c55d75da085af6b5df2eeec5e9b090f561e4180085de1e3'
+        }),
+        expect.objectContaining({
+          l2TxHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+        }),
+        expect.objectContaining({
+          l2TxHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+        }),
+        expect.objectContaining({
+          l2TxHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
+        }),
+        expect.objectContaining({
+          l2TxHash:
+            '0xcadc107f28597db5a2dcb99390eedda0efda46e2eac5aa378a04479908385496'
         })
       ])
     )

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsFromSubgraph.test.ts
@@ -4,12 +4,14 @@ import { fetchTokenWithdrawalsFromSubgraph } from '../fetchTokenWithdrawalsFromS
 
 const l2Provider = new JsonRpcProvider('https://arb1.arbitrum.io/rpc')
 
-jest.setTimeout(10000)
+const l2UserAddress = '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299'
+
+/* Note : Please ensure that Block numbers `from` and `to` should be the same in both *fromEventLogs and *fromSubgraph tests */
 
 describe('fetchTokenWithdrawalsFromSubgraph', () => {
   it('fetches no token withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      address: l2UserAddress,
       fromBlock: 0,
       toBlock: 20961063,
       l2Provider
@@ -20,7 +22,7 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some token withdrawals from subgraph pre-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      address: l2UserAddress,
       fromBlock: 20961064,
       toBlock: 26317225,
       l2Provider
@@ -39,7 +41,7 @@ describe('fetchTokenWithdrawalsFromSubgraph', () => {
 
   it('fetches some token withdrawals from subgraph pre-nitro and post-nitro', async () => {
     const result = await fetchTokenWithdrawalsFromSubgraph({
-      address: '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299',
+      address: l2UserAddress,
       fromBlock: 20961064,
       toBlock: 35134792,
       l2Provider

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsTestHelpers.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsTestHelpers.ts
@@ -1,0 +1,26 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
+
+const address = '0x2Ce910fBba65B454bBAf6A18c952A70f3bcd8299'
+const l2Provider = new StaticJsonRpcProvider('https://arb1.arbitrum.io/rpc')
+
+const baseQuery = {
+  address,
+  l2Provider,
+  l2GatewayAddresses: [
+    '0x09e9222E96E7B4AE2a407B98d48e330053351EEe', // L2 Standard Gateway
+    '0x096760F208390250649E3e8763348E783AEF5562', // L2 Custom Gateway
+    '0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B' // L2 WETH Gateway
+  ]
+}
+
+export function getQueryCoveringClassicOnlyWithoutResults() {
+  return { ...baseQuery, fromBlock: 0, toBlock: 20961063 }
+}
+
+export function getQueryCoveringClassicOnlyWithResults() {
+  return { ...baseQuery, fromBlock: 20961064, toBlock: 26317225 }
+}
+
+export function getQueryCoveringClassicAndNitroWithResults() {
+  return { ...baseQuery, fromBlock: 20961064, toBlock: 35134792 }
+}

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsTestHelpers.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsTestHelpers.ts
@@ -18,7 +18,7 @@ export function getQueryCoveringClassicOnlyWithoutResults() {
 }
 
 export function getQueryCoveringClassicOnlyWithResults() {
-  return { ...baseQuery, fromBlock: 20961064, toBlock: 22207817 }
+  return { ...baseQuery, fromBlock: 20961064, toBlock: 22207816 }
 }
 
 export function getQueryCoveringClassicAndNitroWithResults() {

--- a/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsTestHelpers.ts
+++ b/packages/token-bridge-sdk/src/withdrawals/__test__/fetchTokenWithdrawalsTestHelpers.ts
@@ -18,7 +18,7 @@ export function getQueryCoveringClassicOnlyWithoutResults() {
 }
 
 export function getQueryCoveringClassicOnlyWithResults() {
-  return { ...baseQuery, fromBlock: 20961064, toBlock: 26317225 }
+  return { ...baseQuery, fromBlock: 20961064, toBlock: 22207817 }
 }
 
 export function getQueryCoveringClassicAndNitroWithResults() {


### PR DESCRIPTION
Updated the test-addresses + RPC endpoint + txHashes used in the `arbOne` subgraph.

<img width="717" alt="image" src="https://user-images.githubusercontent.com/7558499/200554760-fd45e2ff-17b6-4b7d-b70b-b512ad5f46dc.png">
