### PR TITLE
test: fix numbers wrongly formatted in non-english browser

### DIFF
--- a/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/depositERC20.cy.ts
@@ -96,7 +96,7 @@ describe('Deposit ERC20 Token', () => {
             cy.findByText('You’re moving')
               .siblings()
               .last()
-              .contains('0.0001 LINK')
+              .contains(formatAmount(0.0001))
               .should('be.visible')
             cy.findByText('You’ll pay in gas fees')
               .siblings()
@@ -125,9 +125,11 @@ describe('Deposit ERC20 Token', () => {
           .click({ scrollBehavior: false })
           .then(() => {
             cy.confirmMetamaskTransaction().then(() => {
-              cy.findByText(/Moving 0.0001 LINK to Arbitrum Goerli.../i).should(
-                'be.visible'
-              )
+              cy.findByText(
+                `Moving ${formatAmount(0.0001, {
+                  symbol: 'LINK'
+                })} to Arbitrum Goerli...`
+              ).should('be.visible')
             })
           })
       })

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/depositETH.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/depositETH.cy.ts
@@ -4,6 +4,7 @@
 
 import { resetSeenTimeStampCache } from '../../support/commands'
 import { zeroToLessThanOneETH } from '../../support/common'
+import { formatAmount } from '../../../src/util/NumberUtils'
 
 describe('Deposit ETH', () => {
   // when all of our tests need to run in a logged-in state
@@ -57,7 +58,7 @@ describe('Deposit ETH', () => {
             cy.findByText('You’re moving')
               .siblings()
               .last()
-              .contains('0.0001 ETH')
+              .contains(formatAmount(0.0001, { symbol: 'ETH' }))
               .should('be.visible')
             cy.findByText('You’ll pay in gas fees')
               .siblings()
@@ -98,9 +99,11 @@ describe('Deposit ETH', () => {
         // https://github.com/cypress-io/cypress/issues/23898
 
         cy.confirmMetamaskTransaction().then(() => {
-          cy.findByText('Moving 0.0001 ETH to Arbitrum Goerli...').should(
-            'be.visible'
-          )
+          cy.findByText(
+            `Moving ${formatAmount(0.0001, {
+              symbol: 'ETH'
+            })} to Arbitrum Goerli...`
+          ).should('be.visible')
         })
       })
     })

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawERC20.cy.ts
@@ -103,7 +103,7 @@ describe('Withdraw ERC20 Token', () => {
             cy.findByText('You’re moving')
               .siblings()
               .last()
-              .contains('0.0001 LINK')
+              .contains(formatAmount(0.0001, { symbol: 'LINK' }))
               .should('be.visible')
             cy.findByText(/You’ll pay in gas/i)
               .siblings()
@@ -162,9 +162,11 @@ describe('Withdraw ERC20 Token', () => {
               .click({ scrollBehavior: false })
 
             cy.confirmMetamaskTransaction().then(() => {
-              cy.findAllByText(/Moving 0.0001 LINK to Goerli/i).should(
-                'be.visible'
-              )
+              cy.findAllByText(
+                `Moving ${formatAmount(0.0001, {
+                  symbol: 'LINK'
+                })} to Goerli...`
+              ).should('be.visible')
             })
           })
       })

--- a/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawETH.cy.ts
+++ b/packages/arb-token-bridge-ui/tests/e2e/specs/withdrawETH.cy.ts
@@ -4,6 +4,7 @@
 
 import { resetSeenTimeStampCache } from '../../support/commands'
 import { zeroToLessThanOneETH } from '../../support/common'
+import { formatAmount } from '../../../src/util/NumberUtils'
 
 describe('Withdraw ETH', () => {
   // when all of our tests need to run in a logged-in state
@@ -56,7 +57,7 @@ describe('Withdraw ETH', () => {
             cy.findByText('You’re moving')
               .siblings()
               .last()
-              .contains('0.0001 ETH')
+              .contains(formatAmount(0.0001, { symbol: 'ETH' }))
               .should('be.visible')
             cy.findByText('You’ll pay in gas fees')
               .siblings()
@@ -123,7 +124,9 @@ describe('Withdraw ETH', () => {
 
       it('should withdraw successfully', () => {
         cy.confirmMetamaskTransaction().then(() => {
-          cy.findAllByText(/Moving 0.0001 ETH to Goerli/i).should('be.visible')
+          cy.findAllByText(
+            `Moving ${formatAmount(0.0001, { symbol: 'ETH' })} to Goerli...`
+          ).should('be.visible')
         })
       })
     })


### PR DESCRIPTION
Non-english language (e.g. French) allows `,` as decimal separator (instead of comma).
<img width="507" alt="image" src="https://user-images.githubusercontent.com/5085333/200378653-78ac597f-d27e-404d-af1b-3266fc663f03.png">

Using `cy.type(0.0001)` type `0,0001` in the input. We're now reading the formatted version in e2e test.
