### PR TITLE
fix: use deposit request for token deposits

### DIFF
--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -481,11 +481,17 @@ export const useArbTokenBridge = (
       l2Provider: l2.provider
     })
 
-    const tx = await erc20Bridger.deposit({
-      l1Signer,
+    const depositRequest = await erc20Bridger.getDepositRequest({
+      l1Provider: l1.provider,
       l2Provider: l2.provider,
+      from: walletAddress,
       erc20L1Address,
       amount
+    })
+
+    const tx = await erc20Bridger.deposit({
+      ...depositRequest,
+      l1Signer
     })
 
     if (txLifecycle?.onTxSubmit) {


### PR DESCRIPTION
When using `getDepositRequest`, we're always relying on the passed in `l1Provider`.