### PR TITLE
chore: remove inapplicable advisory from ignore list

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -17,12 +17,6 @@
     // arb-token-bridge-ui>@walletconnect/web3-provider>web3-provider-engine>async
     // arb-token-bridge-ui>@walletconnect/web3-provider>web3-provider-engine>ethereumjs-block>async
     // arb-token-bridge-ui>@walletconnect/web3-provider>web3-provider-engine>ethereumjs-vm>async-eventemitter>async
-    "GHSA-fwr7-v2mv-hh25",
-    // https://github.com/advisories/GHSA-w573-4hg7-7wgq
-    // decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS
-    // this is from decode-uri-component, a dependency used in query-string,
-    // which we have installed directly and through @walletconnect/web3-provider
-    // it does not affect users directly so we'll ignore it for now and wait for a patch
-    "GHSA-w573-4hg7-7wgq"
+    "GHSA-fwr7-v2mv-hh25"
   ]
 }

--- a/packages/arb-token-bridge-ui/package.json
+++ b/packages/arb-token-bridge-ui/package.json
@@ -21,7 +21,7 @@
     "lodash-es": "^4.17.21",
     "overmind": "^28.0.1",
     "overmind-react": "^29.0.1",
-    "query-string": "^7.1.1",
+    "query-string": "^7.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-loader-spinner": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8694,7 +8694,7 @@ decimal.js@^10.2.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
-decode-uri-component@^0.2.0:
+decode-uri-component@^0.2.0, decode-uri-component@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
@@ -18681,12 +18681,12 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
-  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+query-string@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
+  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
   dependencies:
-    decode-uri-component "^0.2.0"
+    decode-uri-component "^0.2.2"
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"


### PR DESCRIPTION
remove this because #517 updated the dependency to a non-vulnerable version