### PR TITLE
fix: pin commit of warningTokens.json

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/App.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/App.tsx
@@ -243,7 +243,7 @@ const Injector = ({ children }: { children: React.ReactNode }): JSX.Element => {
   useEffect(() => {
     axios
       .get(
-        'https://raw.githubusercontent.com/OffchainLabs/arb-token-lists/master/src/WarningList/warningTokens.json'
+        'https://raw.githubusercontent.com/OffchainLabs/arb-token-lists/aff40a59608678cfd9b034dd198011c90b65b8b6/src/WarningList/warningTokens.json'
       )
       .then(res => {
         actions.app.setWarningTokens(res.data)


### PR DESCRIPTION
### Summary

Pin commit of `warningToken`, if `warningToken` changes in master in token-list repo, we will still be fetching the same version which we knows is working.
