### PR TITLE
fix: adjust spacing in summary panel

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanel.tsx
@@ -769,24 +769,26 @@ export function TransferPanel() {
           }
           className="flex w-full flex-col justify-between bg-gray-3 px-6 py-6 lg:rounded-tr-xl lg:rounded-br-xl lg:bg-white lg:px-0 lg:pr-6"
         >
-          <div className="hidden lg:block">
-            <span className="text-2xl">Summary</span>
-            <div className="h-4" />
-          </div>
-
-          {isSummaryVisible ? (
-            <TransferPanelSummary
-              amount={amountNum}
-              token={selectedToken}
-              gasSummary={gasSummary}
-            />
-          ) : (
-            <div className="hidden text-lg text-gray-7 lg:block lg:min-h-[297px]">
-              <span className="text-xl">
-                Bridging summary will appear here.
-              </span>
+          <div className="flex flex-col">
+            <div className="hidden lg:block">
+              <span className="text-2xl">Summary</span>
+              <div className="h-4" />
             </div>
-          )}
+
+            {isSummaryVisible ? (
+              <TransferPanelSummary
+                amount={amountNum}
+                token={selectedToken}
+                gasSummary={gasSummary}
+              />
+            ) : (
+              <div className="hidden text-lg text-gray-7 lg:block lg:min-h-[297px]">
+                <span className="text-xl">
+                  Bridging summary will appear here.
+                </span>
+              </div>
+            )}
+          </div>
 
           {isDepositMode ? (
             <Button


### PR DESCRIPTION
We are going to have extra data below network selectors, such as advanced settings with destination address input.

This causes layout issues in the summary panel: `Bridging summary will appear here text` is shifted down.

**Solution:** only added `<div className="flex flex-col">` wrapper. GitHub formatting might make it harder to see.

Before:
<img width="1094" alt="Screenshot 2022-12-16 at 13 00 23" src="https://user-images.githubusercontent.com/47932951/208093754-dc844887-d1a4-4ed1-8f77-179359bfa70f.png">


After:
<img width="1094" alt="Screenshot 2022-12-16 at 12 59 39" src="https://user-images.githubusercontent.com/47932951/208093654-2bd3023d-f936-4482-b53f-f70b9873f4dc.png">

Non-empty summary panel unaffected:
<img width="1094" alt="Screenshot 2022-12-16 at 13 04 42" src="https://user-images.githubusercontent.com/47932951/208094381-b2a19f29-9919-4b35-89cf-50eab09b3197.png">
