### PR TITLE
chore: update twitter request faucet text

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useTwitter.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useTwitter.ts
@@ -6,8 +6,8 @@ const useTwitter = () => {
   } = useAppState()
   const walletAddress = arbTokenBridge.walletAddress
   const text =
-    `ok I need @arbitrum to give me Nitro testnet gas. like VERY SOON. I cant take this, I’ve been waiting for @nitro_devnet release. I just want to start developing. but I need the gas IN MY WALLET NOW. can devs DO SOMETHING?? \r\n SEND HERE: ${
-      walletAddress || '0x*YOUR**ETH**ADDRESS**GOES**HERE**'
+    `Ok I need @arbitrum to give me Arbitrum Goerli testnet gas. I can't wait to start developing on @nitro_devnet. \r\n SEND HERE: ${
+      walletAddress ?? '0x*YOUR**ETH**ADDRESS**GOES**HERE**'
     }`
       .split(' ')
       .join('%20')


### PR DESCRIPTION
Text is as seen on https://github.com/OffchainLabs/arbitrum-docs/pull/64

### Steps to test
connect to testnet and click "Request ETH from the Nitro Testnet Twitter faucet!"
it should say
> Ok I need @ arbitrum to give me Arbitrum Goerli testnet gas. I can't wait to start developing on @nitro_devnet.  SEND HERE: {wallet address}

^ space is added to not trigger github tag