### PR TITLE
feat: add link to the arbitrum nova portal

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/Header.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Header.tsx
@@ -216,8 +216,12 @@ export function Header() {
             <HeaderMenuDesktop
               items={[
                 {
-                  title: 'App Portal',
+                  title: 'Arbitrum One Portal',
                   anchorProps: { href: 'https://portal.arbitrum.one' }
+                },
+                {
+                  title: 'Arbitrum Nova Portal',
+                  anchorProps: { href: 'https://portal-nova.arbitrum.io' }
                 },
                 {
                   title: 'Explorers',
@@ -307,8 +311,12 @@ function HeaderMobile() {
         <HeaderMenuMobile
           items={[
             {
-              title: 'App Portal',
+              title: 'Arbitrum One Portal',
               anchorProps: { href: 'https://portal.arbitrum.one' }
+            },
+            {
+              title: 'Arbitrum Nova Portal',
+              anchorProps: { href: 'https://portal-nova.arbitrum.io' }
             }
           ]}
         >


### PR DESCRIPTION
### Summary

Adds a link to the Arbitrum Nova portal in the Ecosystem dropdown.