### PR TITLE
feat: Fathom event sequence

### DIFF
--- a/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
@@ -251,9 +251,8 @@ export function trackEvent(
     return
   }
 
-  pushEventToStorage(event)
-
   if (isValidEventSequence(requiredSequence)) {
     window.fathom.trackGoal(eventToEventId[event])
   }
+  pushEventToStorage(event)
 }


### PR DESCRIPTION
As of now we fire basic Fathom events without any conditions. Because of this, we can't reliably analyse data of the entire journey and user behavior on the bridge.

Adding `Event Groups` allows us to map individual events into groups, so that e.g. we know if a user made a transfer instead of depositing or withdrawing a specific token on a specific network.

We also store call sequence of specific groups. Using this we can conditionally call events based on an event sequence that happened in the past. We can check if user opened a history tab after transferring, and then went to press a 'Get Help' button or opened an explorer, and whatever sequence we want.