### PR TITLE
feat: display timezone in transactions

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/common/SidePanel.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/SidePanel.tsx
@@ -24,7 +24,7 @@ export const SidePanel = ({
         {/* Full-screen container to center the panel */}
         <div className="fixed inset-0 top-0 right-0 flex h-full w-full items-start justify-end overflow-y-auto">
           {/* The heading of dialog  */}
-          <Dialog.Panel className="flex h-full w-full flex-col bg-dark lg:w-1/2 lg:min-w-[700px]">
+          <Dialog.Panel className="flex h-full w-full flex-col bg-dark lg:w-1/2 lg:min-w-[900px]">
             <Dialog.Title className="sticky top-0 z-50 mx-4 flex flex-row justify-between border-b-[1px] border-gray-9 bg-dark py-4 text-white">
               <span className="text-xl">{heading}</span>
               <button className="arb-hover" onClick={onClose}>

--- a/packages/arb-token-bridge-ui/src/pages/_app.tsx
+++ b/packages/arb-token-bridge-ui/src/pages/_app.tsx
@@ -4,6 +4,8 @@ import * as Sentry from '@sentry/react'
 import { BrowserTracing } from '@sentry/tracing'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import advancedFormat from 'dayjs/plugin/advancedFormat'
+import timeZone from 'dayjs/plugin/timezone'
 
 import 'tippy.js/dist/tippy.css'
 import 'tippy.js/themes/light.css'
@@ -19,6 +21,8 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 dayjs.extend(relativeTime)
+dayjs.extend(timeZone)
+dayjs.extend(advancedFormat)
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/packages/arb-token-bridge-ui/src/state/app/utils.ts
+++ b/packages/arb-token-bridge-ui/src/state/app/utils.ts
@@ -11,7 +11,7 @@ import {
 import { DepositStatus, MergedTransaction } from './state'
 
 export const TX_DATE_FORMAT = 'MMM DD, YYYY'
-export const TX_TIME_FORMAT = 'hh:mm A'
+export const TX_TIME_FORMAT = 'hh:mm A (z)'
 
 export const outgoungStateToString = {
   [OutgoingMessageState.UNCONFIRMED]: 'Unconfirmed',


### PR DESCRIPTION
A minor enhancement to add timezone offset abbreviations to the dates being shown in transaction history.
I added it as a separate PR to confirm the approach and experience.

Note: Not ALL timezones map to an abbreviation/short name like `GMT`, `PST`, etc. In those cases, the library fallbacks to showing `GMT +5.30` format for timezones.

Screenshots : 

<p float="left">
<img height="100px" src="https://user-images.githubusercontent.com/7558499/223386076-8208fe23-ba7c-40ef-8c69-e1d00d66ccad.png" />
<img height="100px" src="https://user-images.githubusercontent.com/7558499/223386153-9e2951f1-c4d3-4931-9910-0fd624ba3b01.png" />
<img height="100px" src="https://user-images.githubusercontent.com/7558499/223386298-82000b2f-6abc-41a2-a4c7-8de317bc6ac3.png" />
</p>
