### PR TITLE
fix: show completion time for token deposits in tx history

### DIFF
--- a/packages/token-bridge-sdk/src/util/deposits.ts
+++ b/packages/token-bridge-sdk/src/util/deposits.ts
@@ -172,9 +172,7 @@ const updateAdditionalDepositDataToken = async ({
     retryableCreationTxID: l1ToL2Msg.retryableCreationId
   }
 
-  const isDeposited =
-    l1ToL2MsgData.status === L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2 ||
-    l1ToL2MsgData.status === L1ToL2MessageStatus.REDEEMED
+  const isDeposited = l1ToL2MsgData.status === L1ToL2MessageStatus.REDEEMED
 
   const l2BlockNum = isDeposited
     ? (await l2Provider.getTransaction(l1ToL2Msg.retryableCreationId))

--- a/packages/token-bridge-sdk/src/util/deposits.ts
+++ b/packages/token-bridge-sdk/src/util/deposits.ts
@@ -173,7 +173,8 @@ const updateAdditionalDepositDataToken = async ({
   }
 
   const isDeposited =
-    l1ToL2MsgData.status === L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2
+    l1ToL2MsgData.status === L1ToL2MessageStatus.FUNDS_DEPOSITED_ON_L2 ||
+    l1ToL2MsgData.status === L1ToL2MessageStatus.REDEEMED
 
   const l2BlockNum = isDeposited
     ? (await l2Provider.getTransaction(l1ToL2Msg.retryableCreationId))


### PR DESCRIPTION
### Before
Only creation time was visible for completed token deposits
<img height="150" alt="image" src="https://user-images.githubusercontent.com/7558499/223699842-793a2b59-233b-4701-a745-60f06017390c.png">


### After
Both creation + completion time is visible for completed token deposits
<img height="150" alt="image" src="https://user-images.githubusercontent.com/7558499/223699984-0dd0f1d2-124a-4440-9a45-03fd2b747394.png">
