### PR TITLE
feat: show pending claim withdrawals' banner on front page

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react'
 import { useDeposits } from '../../hooks/useDeposits'
 import { PageParams } from '../TransactionHistory/TransactionsTable/TransactionsTable'
 import { useWithdrawals } from '../../hooks/useWithdrawals'
-import { PendingClaimsInfo } from '../TransactionHistory/PendingClaimsInfo'
+import { WithdrawalsReadyToClaimInfo } from '../TransactionHistory/WithdrawalsReadyToClaimInfo'
 
 export const motionDivProps = {
   layout: true,
@@ -89,7 +89,7 @@ export function MainContent() {
     <div className="flex w-full justify-center">
       <div className="w-full max-w-screen-lg flex-col space-y-6">
         {/* if the user has some pending claim txns, show that bar here */}
-        <PendingClaimsInfo />
+        <WithdrawalsReadyToClaimInfo />
 
         <AnimatePresence>
           <motion.div

--- a/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
+++ b/packages/arb-token-bridge-ui/src/components/MainContent/MainContent.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react'
 import { useDeposits } from '../../hooks/useDeposits'
 import { PageParams } from '../TransactionHistory/TransactionsTable/TransactionsTable'
 import { useWithdrawals } from '../../hooks/useWithdrawals'
+import { PendingClaimsInfo } from '../TransactionHistory/PendingClaimsInfo'
 
 export const motionDivProps = {
   layout: true,
@@ -87,6 +88,9 @@ export function MainContent() {
   return (
     <div className="flex w-full justify-center">
       <div className="w-full max-w-screen-lg flex-col space-y-6">
+        {/* if the user has some pending claim txns, show that bar here */}
+        <PendingClaimsInfo />
+
         <AnimatePresence>
           <motion.div
             key="transfer-panel"

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/PendingClaimsInfo.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/PendingClaimsInfo.tsx
@@ -40,7 +40,8 @@ export const PendingClaimsInfo = () => {
       <CheckCircleIcon className="h-4 w-4" />
       You have
       <span className="font-bold">{numPendingClaimTransactions}</span>
-      withdrawals <span className="font-bold">ready to claim.</span>
+      {`${numPendingClaimTransactions > 1 ? 'withdrawals' : 'withdrawal'}`}{' '}
+      <span className="font-bold">ready to claim.</span>
       <ExternalLink
         className="arb-hover cursor-pointer text-sm text-blue-link underline"
         onClick={() => {

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/PendingClaimsInfo.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/PendingClaimsInfo.tsx
@@ -1,0 +1,62 @@
+/*
+  A small info banner that we show when the user has some pending claims.
+  Format: "You have [X] withdrawals ready to claim. [CTA]" 
+*/
+
+import { CheckCircleIcon } from '@heroicons/react/outline'
+import { OutgoingMessageState } from 'token-bridge-sdk'
+import { useNetworksAndSigners } from '../../hooks/useNetworksAndSigners'
+import { useAppState } from '../../state'
+import { isPending, outgoungStateToString } from '../../state/app/utils'
+import { isFathomNetworkName, trackEvent } from '../../util/AnalyticsUtils'
+import { getNetworkName } from '../../util/networks'
+import { useAppContextDispatch } from '../App/AppContext'
+import { ExternalLink } from '../common/ExternalLink'
+
+export const PendingClaimsInfo = () => {
+  const {
+    l2: { network: l2Network }
+  } = useNetworksAndSigners()
+
+  const {
+    app: { mergedTransactions }
+  } = useAppState()
+
+  const l2NetworkName = getNetworkName(l2Network.chainID)
+
+  const dispatch = useAppContextDispatch()
+
+  const numPendingClaimTransactions = mergedTransactions.filter(
+    tx =>
+      isPending(tx) &&
+      tx.status === outgoungStateToString[OutgoingMessageState.CONFIRMED]
+  ).length
+
+  // don't show this if user doesn't have anything to claim
+  if (!numPendingClaimTransactions) return null
+
+  return (
+    <div className="flex items-center gap-1 rounded-md bg-lime p-2 text-base text-lime-dark lg:flex-nowrap">
+      <CheckCircleIcon className="h-4 w-4" />
+      You have
+      <span className="font-bold">{numPendingClaimTransactions}</span>
+      withdrawals <span className="font-bold">ready to claim.</span>
+      <ExternalLink
+        className="arb-hover cursor-pointer text-sm text-blue-link underline"
+        onClick={() => {
+          dispatch({
+            type: 'layout.set_txhistory_panel_visible',
+            payload: true
+          })
+          if (isFathomNetworkName(l2NetworkName)) {
+            trackEvent(
+              `Open Transaction History Click: Withdrawals Ready Banner`
+            )
+          }
+        }}
+      >
+        Open Transaction History panel.
+      </ExternalLink>
+    </div>
+  )
+}

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/WithdrawalsReadyToClaimInfo.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/WithdrawalsReadyToClaimInfo.tsx
@@ -13,7 +13,7 @@ import { getNetworkName } from '../../util/networks'
 import { useAppContextDispatch } from '../App/AppContext'
 import { ExternalLink } from '../common/ExternalLink'
 
-export const PendingClaimsInfo = () => {
+export const WithdrawalsReadyToClaimInfo = () => {
   const {
     l2: { network: l2Network }
   } = useNetworksAndSigners()
@@ -33,7 +33,7 @@ export const PendingClaimsInfo = () => {
   ).length
 
   // don't show this if user doesn't have anything to claim
-  if (!numPendingClaimTransactions) return null
+  if (numPendingClaimTransactions === 0) return null
 
   return (
     <div className="flex items-center gap-1 rounded-md bg-lime p-2 text-base text-lime-dark lg:flex-nowrap">

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/WithdrawalsReadyToClaimInfo.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/WithdrawalsReadyToClaimInfo.tsx
@@ -26,21 +26,21 @@ export const WithdrawalsReadyToClaimInfo = () => {
 
   const dispatch = useAppContextDispatch()
 
-  const numPendingClaimTransactions = mergedTransactions.filter(
+  const numWithdrawalsReadyToClaim = mergedTransactions.filter(
     tx =>
       isPending(tx) &&
       tx.status === outgoungStateToString[OutgoingMessageState.CONFIRMED]
   ).length
 
   // don't show this if user doesn't have anything to claim
-  if (numPendingClaimTransactions === 0) return null
+  if (numWithdrawalsReadyToClaim === 0) return null
 
   return (
     <div className="flex items-center gap-1 rounded-md bg-lime p-2 text-base text-lime-dark lg:flex-nowrap">
       <CheckCircleIcon className="h-4 w-4" />
       You have
-      <span className="font-bold">{numPendingClaimTransactions}</span>
-      {`${numPendingClaimTransactions > 1 ? 'withdrawals' : 'withdrawal'}`}{' '}
+      <span className="font-bold">{numWithdrawalsReadyToClaim}</span>
+      {`${numWithdrawalsReadyToClaim > 1 ? 'withdrawals' : 'withdrawal'}`}{' '}
       <span className="font-bold">ready to claim.</span>
       <ExternalLink
         className="arb-hover cursor-pointer text-sm text-blue-link underline"

--- a/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
+++ b/packages/arb-token-bridge-ui/src/util/AnalyticsUtils.ts
@@ -68,6 +68,7 @@ export type FathomEvent =
   | `Redeem Retryable on ${FathomNetworkName}`
   //
   | `Open Transaction History Click`
+  | `Open Transaction History Click: Withdrawals Ready Banner`
   //
   | `Tx Error: Get Help Click on ${FathomNetworkName}`
   | `Multiple Tx Error: Get Help Click on ${FathomNetworkName}`
@@ -174,6 +175,7 @@ const eventToEventId: { [key in FathomEvent]: string } & {
   'Redeem Retryable on Arbitrum Nova': 'AQDHUKER',
   //
   'Open Transaction History Click': 'BNE3W7KB',
+  'Open Transaction History Click: Withdrawals Ready Banner': 'I9AMOFHA',
   //
   'Tx Error: Get Help Click on Arbitrum One': 'HT1BWVVI',
   'Tx Error: Get Help Click on Arbitrum Nova': 'XD5VYLPU',


### PR DESCRIPTION
### Summary
Earlier there used to be Pending transaction cards right in front of the user and not hidden in the Tx history panel. With this feature, we will have this pending tx info right at the page center as well.


### Steps to test
- Have some pending, claimable transactions
- The banner with the text `You have [X] withdrawals ready to claim.` will appear right on top of the transfer panel in front page. See the screenshot.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/7558499/224004255-44bd9715-bc23-479e-ba6b-42c27364d467.png">
