### PR TITLE
fix: tab text wrapping to next line

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
@@ -65,7 +65,7 @@ export const TransactionHistory = ({
       {/* Transaction history table */}
       <div>
         <Tab.Group>
-          <Tab.List className={'flex flex-row'}>
+          <Tab.List className={'flex flex-row whitespace-nowrap'}>
             <Tab as={Fragment}>
               {({ selected }) => (
                 <button
@@ -77,7 +77,7 @@ export const TransactionHistory = ({
                   {selected && (
                     <img
                       src={getNetworkLogo(l2.network.chainID)}
-                      className="max-w-6 max-h-6"
+                      className="h-6 max-w-6"
                       alt="Deposit"
                     />
                   )}
@@ -96,7 +96,7 @@ export const TransactionHistory = ({
                   {selected && (
                     <img
                       src={getNetworkLogo(l1.network.chainID)}
-                      className="max-w-6 max-h-6"
+                      className="h-6 max-w-6"
                       alt="Withdraw"
                     />
                   )}

--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
@@ -77,7 +77,7 @@ export const TransactionHistory = ({
                   {selected && (
                     <img
                       src={getNetworkLogo(l2.network.chainID)}
-                      className="h-6 max-w-6"
+                      className="max-w-6 h-6"
                       alt="Deposit"
                     />
                   )}
@@ -96,7 +96,7 @@ export const TransactionHistory = ({
                   {selected && (
                     <img
                       src={getNetworkLogo(l1.network.chainID)}
-                      className="h-6 max-w-6"
+                      className="max-w-6 h-6"
                       alt="Withdraw"
                     />
                   )}


### PR DESCRIPTION
### Before
<img width="504" alt="image" src="https://user-images.githubusercontent.com/7558499/225964463-6f686cac-681f-46bb-8e2b-be88e7c13cf7.png">

### After
<img width="375" alt="image" src="https://user-images.githubusercontent.com/7558499/225964555-933574f4-3a14-4a2e-8a92-9e68e7c022bc.png">
