### PR TITLE
fix: distorted icons in header

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransactionHistory/TransactionHistory.tsx
@@ -77,7 +77,7 @@ export const TransactionHistory = ({
               {/* Deposits */}
               <img
                 src={getNetworkLogo(l2.network.chainID)}
-                className="max-w-6 h-6"
+                className="h-6 max-w-6"
                 alt="Deposit"
               />
               {`To ${getNetworkName(l2.network.chainID)}`}
@@ -89,7 +89,7 @@ export const TransactionHistory = ({
               {/* Withdrawals */}
               <img
                 src={getNetworkLogo(l1.network.chainID)}
-                className="max-w-6 h-6"
+                className="h-6 max-w-6"
                 alt="Withdraw"
               />
               {`To ${getNetworkName(l1.network.chainID)}`}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TransferPanelMain.tsx
@@ -150,7 +150,7 @@ function NetworkListbox({
                   <img
                     src={getNetworkLogo(option.chainID)}
                     alt={`${getNetworkName(option.chainID)} logo`}
-                    className="max-w-8 max-h-9"
+                    className="max-h-9 max-w-8"
                   />
                 </div>
                 <span>{getNetworkName(option.chainID)}</span>

--- a/packages/arb-token-bridge-ui/src/components/common/Header.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/Header.tsx
@@ -301,7 +301,7 @@ const HeaderItemLogo = ({ src, alt }: { src: string; alt: string }) => {
     <Image
       src={src}
       alt={alt}
-      className="max-w-8 mr-4 max-h-8"
+      className="mr-4 max-h-8 max-w-8"
       width={50}
       height={50}
     />

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkInformation.tsx
@@ -27,7 +27,7 @@ export function HeaderNetworkInformation() {
         <img
           src={getNetworkLogo(network.chainID)}
           alt={`${networkName} logo`}
-          className="max-w-8 max-h-8"
+          className="max-h-8 max-w-8"
         />
       </div>
 

--- a/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkNotSupported.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/HeaderNetworkNotSupported.tsx
@@ -11,7 +11,7 @@ export function HeaderNetworkNotSupported() {
         <span className="text-2xl text-brick lg:text-base">Wrong network</span>
         <ChevronDownIcon className="h-4 w-4" />
       </div>
-      <span className="max-w-64 p-2 text-left text-sm text-brick lg:hidden lg:text-center">
+      <span className="p-2 text-left text-sm text-brick lg:hidden lg:text-center">
         Please change your network in your wallet to either Mainnet or Arbitrum
       </span>
     </div>

--- a/packages/arb-token-bridge-ui/src/components/common/MainNetworkNotSupported.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/MainNetworkNotSupported.tsx
@@ -61,7 +61,7 @@ export const MainNetworkNotSupported = ({
               <img
                 src={getNetworkLogo(Number(chainId))}
                 alt={`${getNetworkName(Number(chainId))} logo`}
-                className="max-w-8 max-h-8"
+                className="max-h-8 max-w-8"
               />
             </div>
             <span> {`Switch to ${getNetworkName(Number(chainId))}`}</span>

--- a/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
+++ b/packages/arb-token-bridge-ui/src/components/common/NetworkSelectionContainer.tsx
@@ -62,7 +62,7 @@ export const NetworkSelectionContainer = ({
                   <img
                     src={getNetworkLogo(Number(chainId))}
                     alt={`${getNetworkName(Number(chainId))} logo`}
-                    className="lg:max-w-8 max-w-6 max-h-6 lg:max-h-8"
+                    className="max-h-6 max-w-6 lg:max-h-8 lg:max-w-8"
                   />
                 </div>
                 <span className="whitespace-nowrap">

--- a/packages/arb-token-bridge-ui/tailwind.config.js
+++ b/packages/arb-token-bridge-ui/tailwind.config.js
@@ -55,6 +55,12 @@ module.exports = {
       },
       fontFamily: {
         serif: "'Space Grotesk', sans-serif"
+      },
+      maxWidth: {
+        2: '0.5rem',
+        4: '1rem',
+        6: '1.5rem',
+        8: '2rem'
       }
     }
   }


### PR DESCRIPTION
- Fixed distorted icons in header introduced after removing custom CSS classes
- Added the width classes as a part of tailwind config and did a prettier-format after that.

<img height="202" alt="image" src="https://user-images.githubusercontent.com/7558499/227948743-0c27b842-e3bd-4b92-a2c2-ae8b735ad7cd.png">
