### PR TITLE
feat: add info section about lack of support for rebase token to import token dialog

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
@@ -346,8 +346,10 @@ export function TokenImportDialog({
               alt={`${tokenToImport?.name} logo`}
             />
           )}
-          <span className="text-xl font-bold">{tokenToImport?.symbol}</span>
-          <span className="mt-0 mb-4">{tokenToImport?.name}</span>
+          <span className="text-xl font-bold leading-6">
+            {tokenToImport?.symbol}
+          </span>
+          <span className="mb-3 mt-0">{tokenToImport?.name}</span>
           <a
             href={`${getExplorerUrl(l1.network.chainID)}/token/${
               tokenToImport?.address
@@ -361,7 +363,7 @@ export function TokenImportDialog({
           </a>
 
           {status === ImportStatus.UNKNOWN && (
-            <div className="flex w-full justify-start pt-4">
+            <div className="flex w-full justify-center pt-4">
               <Tippy
                 theme="light"
                 content={
@@ -387,7 +389,7 @@ export function TokenImportDialog({
             </div>
           )}
 
-          <div className="mt-4 flex w-full justify-start gap-1 rounded-lg bg-cyan p-3 text-sm text-dark">
+          <div className="mt-6 flex w-full justify-start gap-1 rounded-lg bg-cyan p-3 text-sm text-dark">
             <InformationCircleIcon className="mt-[2px] h-4 w-4 shrink-0 stroke-dark" />
             <p>
               The bridge does not support tokens with non-standard behaviour in

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/TokenImportDialog.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useLatest } from 'react-use'
 import { ERC20BridgeToken, getL1TokenData } from 'token-bridge-sdk'
-import { ExclamationCircleIcon } from '@heroicons/react/outline'
+import {
+  ExclamationCircleIcon,
+  InformationCircleIcon
+} from '@heroicons/react/outline'
 import Tippy from '@tippyjs/react'
 import { Loader } from '../common/atoms/Loader'
 import { useActions, useAppState } from '../../state'
@@ -383,6 +386,16 @@ export function TokenImportDialog({
               </Tippy>
             </div>
           )}
+
+          <div className="mt-4 flex w-full justify-start gap-1 rounded-lg bg-cyan p-3 text-sm text-dark">
+            <InformationCircleIcon className="mt-[2px] h-4 w-4 shrink-0 stroke-dark" />
+            <p>
+              The bridge does not support tokens with non-standard behaviour in
+              balance calculation, i.e. the token balance increases or decreases
+              while sitting in a wallet address. If you are unsure, please
+              contact the team behind the token.
+            </p>
+          </div>
         </div>
       </div>
     </Dialog>


### PR DESCRIPTION
### Summary

<!--
  Explain the **motivation** for making this change. Why was this change necessary?
  What existing problem does the pull request solve?
  Any implementation details to explain? What code paths or UI flow do the code changes hit?
-->
Add some copy to explain that the bridge doesn't support rebase tokens
For most tokens, this can be ignored and is not a warning, so it's in blue.
<img width="709" alt="image" src="https://user-images.githubusercontent.com/13184582/228211195-9f84cdd1-e415-4dc7-abdb-acf7790a111c.png">


### Steps to test

<!--
  How exactly did you verify that your PR solves the issue?
  If applicable, share the steps that a reviewer should follow to validate the new behavior.
  Example: The exact commands you ran and their output, screenshots / gifs / videos if the pull request changes the UI.
-->
Try to import a token on the token search panel. Trigger the import token dialog to open.