### PR TITLE
fix: added error tracing for withdrawal claiming flow

### DIFF
--- a/packages/arb-token-bridge-ui/src/hooks/useClaimWithdrawal.ts
+++ b/packages/arb-token-bridge-ui/src/hooks/useClaimWithdrawal.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-
+import * as Sentry from '@sentry/react'
 import { useAppState } from '../state'
 import { MergedTransaction } from '../state/app/state'
 import { isUserRejectedError } from '../util/isUserRejectedError'
@@ -46,7 +46,7 @@ export function useClaimWithdrawal(): UseClaimWithdrawalResult {
       }
     } catch (error: any) {
       err = error
-      console.warn(err)
+      Sentry.captureException(err)
     } finally {
       setIsClaiming(false)
     }

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -943,31 +943,25 @@ export const useArbTokenBridge = (
       l2ToL1MsgData: { uniqueId: getUniqueIdOrHashFromEvent(event) }
     })
 
-    try {
-      const rec = await res.wait()
+    const rec = await res.wait()
 
-      if (rec.status === 1) {
-        setTransactionSuccess(rec.transactionHash)
-        addToExecutedMessagesCache([event])
-        setPendingWithdrawalMap(oldPendingWithdrawalsMap => {
-          const newPendingWithdrawalsMap = { ...oldPendingWithdrawalsMap }
-          const pendingWithdrawal = newPendingWithdrawalsMap[id]
-          if (pendingWithdrawal) {
-            pendingWithdrawal.outgoingMessageState =
-              OutgoingMessageState.EXECUTED
-          }
+    if (rec.status === 1) {
+      setTransactionSuccess(rec.transactionHash)
+      addToExecutedMessagesCache([event])
+      setPendingWithdrawalMap(oldPendingWithdrawalsMap => {
+        const newPendingWithdrawalsMap = { ...oldPendingWithdrawalsMap }
+        const pendingWithdrawal = newPendingWithdrawalsMap[id]
+        if (pendingWithdrawal) {
+          pendingWithdrawal.outgoingMessageState = OutgoingMessageState.EXECUTED
+        }
 
-          return newPendingWithdrawalsMap
-        })
-      } else {
-        setTransactionFailure(rec.transactionHash)
-      }
-
-      return rec
-    } catch (err) {
-      console.warn('WARNING: token outbox execute failed:', err)
-      throw err // throw error so that it propagates to Sentry in UI
+        return newPendingWithdrawalsMap
+      })
+    } else {
+      setTransactionFailure(rec.transactionHash)
     }
+
+    return rec
   }
 
   async function triggerOutboxEth({
@@ -1001,31 +995,25 @@ export const useArbTokenBridge = (
       l2ToL1MsgData: { uniqueId: getUniqueIdOrHashFromEvent(event) }
     })
 
-    try {
-      const rec = await res.wait()
+    const rec = await res.wait()
 
-      if (rec.status === 1) {
-        setTransactionSuccess(rec.transactionHash)
-        addToExecutedMessagesCache([event])
-        setPendingWithdrawalMap(oldPendingWithdrawalsMap => {
-          const newPendingWithdrawalsMap = { ...oldPendingWithdrawalsMap }
-          const pendingWithdrawal = newPendingWithdrawalsMap[id]
-          if (pendingWithdrawal) {
-            pendingWithdrawal.outgoingMessageState =
-              OutgoingMessageState.EXECUTED
-          }
+    if (rec.status === 1) {
+      setTransactionSuccess(rec.transactionHash)
+      addToExecutedMessagesCache([event])
+      setPendingWithdrawalMap(oldPendingWithdrawalsMap => {
+        const newPendingWithdrawalsMap = { ...oldPendingWithdrawalsMap }
+        const pendingWithdrawal = newPendingWithdrawalsMap[id]
+        if (pendingWithdrawal) {
+          pendingWithdrawal.outgoingMessageState = OutgoingMessageState.EXECUTED
+        }
 
-          return newPendingWithdrawalsMap
-        })
-      } else {
-        setTransactionFailure(rec.transactionHash)
-      }
-
-      return rec
-    } catch (err) {
-      console.warn('WARNING: ETH outbox execute failed:', err)
-      throw err // throw error so that it propagates to Sentry in UI
+        return newPendingWithdrawalsMap
+      })
+    } else {
+      setTransactionFailure(rec.transactionHash)
     }
+
+    return rec
   }
 
   function addToExecutedMessagesCache(events: L2ToL1EventResult[]) {

--- a/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
+++ b/packages/token-bridge-sdk/src/hooks/useArbTokenBridge.ts
@@ -966,6 +966,7 @@ export const useArbTokenBridge = (
       return rec
     } catch (err) {
       console.warn('WARNING: token outbox execute failed:', err)
+      throw err // throw error so that it propagates to Sentry in UI
     }
   }
 
@@ -1023,6 +1024,7 @@ export const useArbTokenBridge = (
       return rec
     } catch (err) {
       console.warn('WARNING: ETH outbox execute failed:', err)
+      throw err // throw error so that it propagates to Sentry in UI
     }
   }
 


### PR DESCRIPTION
- Added Sentry error tracing for the intermittent `Can't claim withdrawal yet` issue
- Added `throw error` to the try-catch block in SDK to propagate the error further