### PR TITLE
fix: incorrect time remaining to withdraw being displayed

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
@@ -82,7 +82,7 @@ export function AppContextProvider({
 
   useEffect(() => {
     setCurrentL1BlockNumber(currentL1BlockNumber)
-  }, [currentL1BlockNumber, setCurrentL1BlockNumber])
+  }, [currentL1BlockNumber])
 
   return (
     <AppContext.Provider value={[state, dispatch]}>

--- a/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
@@ -75,7 +75,7 @@ export function AppContextProvider({
   children: React.ReactNode
 }) {
   const [state, dispatch] = useReducer(reducer, initialState)
-  const { setCurrentL1BlockNumber } = useAppContextActions()
+  const { setCurrentL1BlockNumber } = useAppContextActions(dispatch)
 
   const { l1 } = useNetworksAndSigners()
   const currentL1BlockNumber = useBlockNumber(l1.provider)
@@ -97,9 +97,10 @@ export function useAppContextState(): AppContextState {
 }
 
 // exports actions in a more readable and succinct format
-// deprecates the direct use of `dispatch` in code
-export const useAppContextActions = () => {
-  const [, dispatch] = useContext(AppContext)
+// deprecates the direct use of `dispatch` in code, unless trying to override
+export const useAppContextActions = (dispatchOverride?: Dispatch<Action>) => {
+  const [, dispatchContext] = useContext(AppContext)
+  const dispatch = dispatchOverride ?? dispatchContext
 
   const setTransferring = (payload: boolean) => {
     dispatch({ type: 'layout.set_is_transferring', payload })

--- a/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
+++ b/packages/arb-token-bridge-ui/src/components/App/AppContext.tsx
@@ -75,7 +75,7 @@ export function AppContextProvider({
   children: React.ReactNode
 }) {
   const [state, dispatch] = useReducer(reducer, initialState)
-  const { setCurrentL1BlockNumber } = useAppContextActions(dispatch)
+  const { setCurrentL1BlockNumber } = useAppContextActions(dispatch) // override `dispatch` here because this is currently outside of app-context
 
   const { l1 } = useNetworksAndSigners()
   const currentL1BlockNumber = useBlockNumber(l1.provider)


### PR DESCRIPTION
- As a part of [this](https://github.com/OffchainLabs/arb-token-bridge/pull/635) refactor, we abstracted dispatch functionality into a single, reusable hook.
- In one of the instances (where we set the current L1 block number app-wide) we used this hook OUTSIDE the app's context provider wrapper, which rendered it useless, hence falling back to 0 in this case.
- To display the time remaining to withdraw, we use this L1 block number set in app-state, which was being incorrectly used as 0 and messed up all the calculations.

<img height="100" alt="image" src="https://user-images.githubusercontent.com/7558499/228330386-03163f47-c230-43be-91b6-4a5080f2f7ec.png">