### PR TITLE
fix: icons tx history

### DIFF
--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCard.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/DepositCard.tsx
@@ -126,7 +126,7 @@ export function DepositCardContainer({
         {/* Logo watermark */}
         <Image
           src={getNetworkLogo(l2Network.chainID)}
-          className="absolute left-0 top-[1px] z-10 h-6 max-h-[90px] p-[2px] lg:relative lg:top-0 lg:left-[-30px] lg:h-auto lg:max-w-[90px] lg:opacity-[60%]"
+          className="absolute left-0 top-[1px] z-10 h-8 max-h-[90px] w-auto p-[2px] lg:relative lg:left-[-30px] lg:top-0 lg:h-[4.5rem] lg:w-[initial] lg:max-w-[90px] lg:opacity-[60%]"
           alt="Deposit"
         />
         {/* Actual content */}

--- a/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCard.tsx
+++ b/packages/arb-token-bridge-ui/src/components/TransferPanel/WithdrawalCard.tsx
@@ -108,7 +108,7 @@ export function WithdrawalCardContainer({
         {/* Logo watermark */}
         <Image
           src={getNetworkLogo(ChainId.Mainnet)}
-          className="absolute left-0 top-[1px] z-10 h-6 max-h-[90px] p-[2px] lg:relative lg:top-0 lg:left-[-30px] lg:h-auto lg:max-w-[90px] lg:opacity-[60%]"
+          className="absolute left-0 top-[1px] z-10 h-8 max-h-[90px] w-auto p-[2px] lg:relative lg:left-[-30px] lg:top-0 lg:h-[4.5rem] lg:w-[initial] lg:max-w-[90px] lg:opacity-[60%]"
           alt="Withdrawal"
         />
         {/* Actual content */}


### PR DESCRIPTION
On smaller screens in tx history ETH icon is stretched.

**Before:**
_Large screen:_
<img width="930" alt="Screenshot 2023-03-31 at 17 48 01" src="https://user-images.githubusercontent.com/47932951/229168673-bc361a1e-898c-44d8-b05f-5d587dedfb18.png">
_Smaller screen:_
<img width="619" alt="Screenshot 2023-03-31 at 17 47 49" src="https://user-images.githubusercontent.com/47932951/229168624-f8639c6d-a704-42f6-996f-f6b633c46021.png">

**Fixed:**
_Large screen:_
<img width="861" alt="Screenshot 2023-03-31 at 17 53 35" src="https://user-images.githubusercontent.com/47932951/229169924-db9fc042-ed1c-40ba-aac6-6f3dbc4ac3e8.png">
_Smaller screen:_
<img width="606" alt="Screenshot 2023-03-31 at 17 46 55" src="https://user-images.githubusercontent.com/47932951/229168413-4a005232-56d4-4e59-8f01-9b942bb91449.png">
